### PR TITLE
Fix YAML frontmatter in ray-data and ray-train skills

### DIFF
--- a/05-data-processing/ray-data/SKILL.md
+++ b/05-data-processing/ray-data/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 tags: [Data Processing, Ray Data, Distributed Computing, ML Pipelines, Batch Inference, ETL, Scalable, Ray, PyTorch, TensorFlow]
-dependencies: [ray[data], pyarrow, pandas]
+dependencies: ["ray[data]", pyarrow, pandas]
 ---
 
 # Ray Data - Scalable ML Data Processing

--- a/08-distributed-training/ray-train/SKILL.md
+++ b/08-distributed-training/ray-train/SKILL.md
@@ -5,7 +5,7 @@ version: 1.0.0
 author: Orchestra Research
 license: MIT
 tags: [Ray Train, Distributed Training, Orchestration, Ray, Hyperparameter Tuning, Fault Tolerance, Elastic Scaling, Multi-Node, PyTorch, TensorFlow]
-dependencies: [ray[train], torch, transformers]
+dependencies: ["ray[train]", torch, transformers]
 ---
 
 # Ray Train - Distributed Training Orchestration


### PR DESCRIPTION
Quote dependencies with brackets (ray[data], ray[train]) to fix
YAML parsing errors.

https://claude.ai/code/session_01W55m9cXpr4gbDnJFNZdQHu