### PR TITLE
Add Research Ideation category (2 new skills, 85 total)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "email": "zechen@orchestra-research.com"
   },
   "metadata": {
-    "description": "Comprehensive library of 83 AI research engineering skills enabling autonomous AI research from hypothesis to experimental verification",
+    "description": "Comprehensive library of 85 AI research engineering skills enabling autonomous AI research from hypothesis to experimental verification",
     "version": "1.1.0"
   },
   "plugins": [
@@ -250,6 +250,16 @@
       "strict": false,
       "skills": [
         "./20-ml-paper-writing"
+      ]
+    },
+    {
+      "name": "ideation",
+      "description": "Research ideation frameworks including structured brainstorming and creative thinking. Use when exploring new research directions, generating novel ideas, or seeking fresh angles on existing work.",
+      "source": "./",
+      "strict": false,
+      "skills": [
+        "./21-research-ideation/brainstorming-research-ideas",
+        "./21-research-ideation/creative-thinking-for-research"
       ]
     }
   ]

--- a/21-research-ideation/brainstorming-research-ideas/SKILL.md
+++ b/21-research-ideation/brainstorming-research-ideas/SKILL.md
@@ -1,0 +1,384 @@
+---
+name: brainstorming-research-ideas
+description: Guides researchers through structured ideation frameworks to discover high-impact research directions. Use when exploring new problem spaces, pivoting between projects, or seeking novel angles on existing work.
+version: 1.0.0
+author: Orchestra Research
+license: MIT
+tags: [Research Ideation, Brainstorming, Problem Discovery, Creative Thinking, Research Strategy]
+dependencies: []
+---
+
+# Research Idea Brainstorming
+
+Structured frameworks for discovering the next research idea. This skill provides ten complementary ideation lenses that help researchers move from vague curiosity to concrete, defensible research proposals. Each framework targets a different cognitive mode—use them individually or combine them for comprehensive exploration.
+
+## When to Use This Skill
+
+- Starting a new research direction and need structured exploration
+- Feeling stuck on a current project and want fresh angles
+- Evaluating whether a half-formed idea has real potential
+- Preparing for a brainstorming session with collaborators
+- Transitioning between research areas and seeking high-leverage entry points
+- Reviewing a field and looking for underexplored gaps
+
+**Do NOT use this skill when**:
+- You already have a well-defined research question and need execution guidance
+- You need help with experimental design or methodology (use domain-specific skills)
+- You want a literature review (use `scientific-skills:literature-review`)
+
+---
+
+## Core Ideation Frameworks
+
+### 1. Problem-First vs. Solution-First Thinking
+
+Research ideas originate from two distinct modes. Knowing which mode you are in prevents a common failure: building solutions that lack real problems, or chasing problems without feasible approaches.
+
+**Problem-First** (pain point → method):
+- Start with a concrete failure, bottleneck, or unmet need
+- Naturally yields impactful work because the motivation is intrinsic
+- Risk: may converge on incremental fixes rather than paradigm shifts
+
+**Solution-First** (new capability → application):
+- Start with a new tool, insight, or technique seeking application
+- Often drives breakthroughs by unlocking previously impossible approaches
+- Risk: "hammer looking for a nail"—solution may lack genuine demand
+
+**Workflow**:
+1. Write down your idea in one sentence
+2. Classify it: Is this problem-first or solution-first?
+3. If problem-first → verify the problem matters (who suffers? how much?)
+4. If solution-first → identify at least two genuine problems it addresses
+5. For either mode, articulate the gap: what cannot be done today that this enables?
+
+**Self-Check**:
+- [ ] Can I name a specific person or community who needs this?
+- [ ] Is the problem I am solving actually unsolved (not just under-marketed)?
+- [ ] If solution-first, does the solution create new capability or just replicate existing ones?
+
+---
+
+### 2. The Abstraction Ladder
+
+Every research problem sits at a particular level of abstraction. Deliberately moving up or down the ladder reveals ideas invisible at your current level.
+
+| Direction | Action | Outcome |
+|-----------|--------|---------|
+| **Move Up** (generalize) | Turn a specific result into a broader principle | Framework papers, theoretical contributions |
+| **Move Down** (instantiate) | Test a general paradigm under concrete constraints | Empirical papers, surprising failure analyses |
+| **Move Sideways** (analogize) | Apply same abstraction level to adjacent domain | Cross-pollination, transfer papers |
+
+**Workflow**:
+1. State your current research focus in one sentence
+2. Move UP: What is the general principle behind this? What class of problems does this belong to?
+3. Move DOWN: What is the most specific, constrained instance of this? What happens at the extreme?
+4. Move SIDEWAYS: Where else does this pattern appear in a different field?
+5. For each new level, ask: Is this a publishable contribution on its own?
+
+**Example**:
+- **Current**: "Improving retrieval accuracy for RAG systems"
+- **Up**: "What makes context selection effective for any augmented generation system?"
+- **Down**: "How does retrieval accuracy degrade when documents are adversarially perturbed?"
+- **Sideways**: "Database query optimization uses similar relevance ranking—what can we borrow?"
+
+---
+
+### 3. Tension and Contradiction Hunting
+
+Breakthroughs often come from resolving tensions between widely accepted but seemingly conflicting goals. These contradictions are not bugs—they are the research opportunity.
+
+**Common Research Tensions**:
+
+| Tension Pair | Research Opportunity |
+|-------------|---------------------|
+| Performance ↔ Efficiency | Can we match SOTA with 10x less compute? |
+| Privacy ↔ Utility | Can federated/encrypted methods close the accuracy gap? |
+| Generality ↔ Specialization | When does fine-tuning beat prompting, and why? |
+| Safety ↔ Capability | Can alignment improve rather than tax capability? |
+| Interpretability ↔ Performance | Do mechanistic insights enable better architectures? |
+| Scale ↔ Accessibility | Can small models replicate emergent behaviors? |
+
+**Workflow**:
+1. Pick your research area
+2. List the top 3-5 desiderata (things everyone wants)
+3. Identify pairs that are commonly treated as trade-offs
+4. For each pair, ask: Is this trade-off fundamental or an artifact of current methods?
+5. If artifact → the reconciliation IS your research contribution
+6. If fundamental → characterizing the Pareto frontier is itself valuable
+
+**Self-Check**:
+- [ ] Have I confirmed this tension is real (not just assumed)?
+- [ ] Can I point to papers that optimize for each side independently?
+- [ ] Is my proposed reconciliation technically plausible, not just aspirational?
+
+---
+
+### 4. Cross-Pollination (Analogy Transfer)
+
+Borrowing structural ideas from other disciplines is one of the most generative research heuristics. Many foundational techniques emerged this way—attention mechanisms draw from cognitive science, genetic algorithms from biology, adversarial training from game theory.
+
+**Requirements for a Valid Analogy**:
+- **Structural fidelity**: The mapping must hold at the level of underlying mechanisms, not just surface similarity
+- **Non-obvious connection**: If the link is well-known, the novelty is gone
+- **Testable predictions**: The analogy should generate concrete hypotheses
+
+**High-Yield Source Fields for ML Research**:
+
+| Source Field | Transferable Concepts |
+|-------------|----------------------|
+| Neuroscience | Attention, memory consolidation, hierarchical processing |
+| Physics | Energy-based models, phase transitions, renormalization |
+| Economics | Mechanism design, auction theory, incentive alignment |
+| Ecology | Population dynamics, niche competition, co-evolution |
+| Linguistics | Compositionality, pragmatics, grammatical induction |
+| Control Theory | Feedback loops, stability, adaptive regulation |
+
+**Workflow**:
+1. Describe your problem in domain-agnostic language (strip the jargon)
+2. Ask: What other field solves a structurally similar problem?
+3. Study that field's solution at the mechanism level
+4. Map the solution back to your domain, preserving structural relationships
+5. Generate testable predictions from the analogy
+6. Validate: Does the borrowed idea actually improve outcomes?
+
+---
+
+### 5. The "What Changed?" Principle
+
+Strong ideas often come from revisiting old problems under new conditions. Advances in hardware, scale, data availability, or regulations can invalidate prior assumptions and make previously impractical approaches viable.
+
+**Categories of Change to Monitor**:
+
+| Change Type | Example | Research Implication |
+|------------|---------|---------------------|
+| **Compute** | GPUs 10x faster | Methods dismissed as too expensive become feasible |
+| **Scale** | Trillion-token datasets | Statistical arguments that failed at small scale may now hold |
+| **Regulation** | EU AI Act, GDPR | Creates demand for compliant alternatives |
+| **Tooling** | New frameworks, APIs | Reduces implementation barrier for complex methods |
+| **Failure** | High-profile system failures | Exposes gaps in existing approaches |
+| **Cultural** | New user behaviors | Shifts what problems matter most |
+
+**Workflow**:
+1. Pick a well-known negative result or abandoned approach (3-10 years old)
+2. List the assumptions that led to its rejection
+3. For each assumption, ask: Is this still true today?
+4. If any assumption has been invalidated → re-run the idea under new conditions
+5. Frame the contribution: "X was previously impractical because Y, but Z has changed"
+
+---
+
+### 6. Failure Analysis and Boundary Probing
+
+Understanding where a method breaks is often as valuable as showing where it works. Boundary probing systematically exposes the conditions under which accepted techniques fail.
+
+**Types of Boundaries to Probe**:
+- **Distributional**: What happens with out-of-distribution inputs?
+- **Scale**: Does the method degrade at 10x or 0.1x the typical scale?
+- **Adversarial**: Can the method be deliberately broken?
+- **Compositional**: Does performance hold when combining multiple capabilities?
+- **Temporal**: Does the method degrade over time (concept drift)?
+
+**Workflow**:
+1. Select a widely-used method with strong reported results
+2. Identify the implicit assumptions in its evaluation (dataset, scale, domain)
+3. Systematically violate each assumption
+4. Document where and how the method breaks
+5. Diagnose the root cause of each failure
+6. Propose a fix or explain why the failure is fundamental
+
+**Self-Check**:
+- [ ] Am I probing genuine boundaries, not just confirming known limitations?
+- [ ] Can I explain WHY the method fails, not just THAT it fails?
+- [ ] Does my analysis suggest a constructive path forward?
+
+---
+
+### 7. The Simplicity Test
+
+Before accepting complexity, ask whether a simpler approach suffices. Fields sometimes over-index on elaborate solutions when a streamlined baseline performs competitively.
+
+**Warning Signs of Unnecessary Complexity**:
+- The method has many hyperparameters with narrow optimal ranges
+- Ablations show most components contribute marginally
+- A simple baseline was never properly tuned or evaluated
+- The improvement over baselines is within noise on most benchmarks
+
+**Workflow**:
+1. Identify the current SOTA method for your problem
+2. Strip it to its simplest possible core (what is the one key idea?)
+3. Build that minimal version with careful engineering
+4. Compare fairly: same compute budget, same tuning effort
+5. If the gap is small → the contribution is the simplicity itself
+6. If the gap is large → you now understand what the complexity buys
+
+**Contribution Framing**:
+- "We show that [simple method] with [one modification] matches [complex SOTA]"
+- "We identify [specific component] as the critical driver, not [other components]"
+
+---
+
+### 8. Stakeholder Rotation
+
+Viewing a system from multiple perspectives reveals distinct classes of research questions. Each stakeholder sees different friction, risk, and opportunity.
+
+**Stakeholder Perspectives**:
+
+| Stakeholder | Key Questions |
+|-------------|---------------|
+| **End User** | Is this usable? What errors are unacceptable? What is the latency tolerance? |
+| **Developer** | Is this debuggable? What is the maintenance burden? How does it compose? |
+| **Theorist** | Why does this work? What are the formal guarantees? Where are the gaps? |
+| **Adversary** | How can this be exploited? What are the attack surfaces? |
+| **Ethicist** | Who is harmed? What biases are embedded? Who is excluded? |
+| **Regulator** | Is this auditable? Can decisions be explained? Is there accountability? |
+| **Operator** | What is the cost? How does it scale? What is the failure mode? |
+
+**Workflow**:
+1. Describe your system or method in one paragraph
+2. Assume each stakeholder perspective in turn (spend 5 minutes per role)
+3. For each perspective, list the top 3 concerns or questions
+4. Identify which concerns are unaddressed by existing work
+5. The unaddressed concern with the broadest impact is your research question
+
+---
+
+### 9. Composition and Decomposition
+
+Novelty often emerges from recombination or modularization. Innovation frequently lies not in new primitives, but in how components are arranged or separated.
+
+**Composition** (combining existing techniques):
+- Identify two methods that solve complementary subproblems
+- Ask: What emergent capability arises from combining them?
+- Example: RAG + Chain-of-Thought → retrieval-augmented reasoning
+
+**Decomposition** (breaking apart monolithic systems):
+- Identify a complex system with entangled components
+- Ask: Which component is the actual bottleneck?
+- Example: Decomposing "fine-tuning" into data selection, optimization, and regularization reveals that data selection often matters most
+
+**Workflow**:
+1. List the 5-10 key components or techniques in your area
+2. **Compose**: Pick pairs and ask what happens when you combine them
+3. **Decompose**: Pick a complex method and isolate each component's contribution
+4. For compositions: Does the combination create emergent capabilities?
+5. For decompositions: Does isolation reveal a dominant or redundant component?
+
+---
+
+### 10. The "Explain It to Someone" Test
+
+A strong research idea should be defensible in two sentences to a smart non-expert. This test enforces clarity of purpose and sharpens the value proposition.
+
+**The Two-Sentence Template**:
+> **Sentence 1** (Problem): "[Domain] currently struggles with [specific problem], which matters because [concrete consequence]."
+> **Sentence 2** (Insight): "We [approach] by [key mechanism], which works because [reason]."
+
+**If You Cannot Fill This Template**:
+- The problem may not be well-defined yet → return to Framework 1
+- The insight may not be clear yet → return to Framework 7 (simplify)
+- The significance may not be established → return to Framework 3 (find the tension)
+
+**Calibration Questions**:
+- Would a smart colleague outside your subfield understand why this matters?
+- Does the explanation stand without jargon?
+- Can you predict what a skeptic's first objection would be?
+
+---
+
+## Integrated Brainstorming Workflow
+
+Use this end-to-end workflow to go from blank page to ranked research ideas.
+
+### Phase 1: Diverge (Generate Candidates)
+
+**Goal**: Produce 10-20 candidate ideas without filtering.
+
+1. **Scan for tensions** (Framework 3): List 5 trade-offs in your field
+2. **Check what changed** (Framework 5): List 3 recent shifts (compute, data, regulation)
+3. **Probe boundaries** (Framework 6): Pick 2 popular methods and find where they break
+4. **Cross-pollinate** (Framework 4): Pick 1 idea from an adjacent field
+5. **Compose/decompose** (Framework 9): Combine 2 existing techniques or split 1 apart
+6. **Climb the abstraction ladder** (Framework 2): For each candidate, generate up/down/sideways variants
+
+### Phase 2: Converge (Filter and Rank)
+
+**Goal**: Narrow to 3-5 strongest ideas.
+
+Apply these filters to each candidate:
+
+| Filter | Question | Kill Criterion |
+|--------|----------|----------------|
+| **Explain-It Test** (F10) | Can I state this in two sentences? | If no → idea is not yet clear |
+| **Problem-First Check** (F1) | Is the problem genuine and important? | If no one suffers from this → drop it |
+| **Simplicity Test** (F7) | Is the complexity justified? | If a simpler approach works → simplify or drop |
+| **Stakeholder Check** (F8) | Who benefits? Who might object? | If no clear beneficiary → drop it |
+| **Feasibility** | Can I execute this with available resources? | If clearly infeasible → park it for later |
+
+### Phase 3: Refine (Sharpen the Winner)
+
+**Goal**: Turn the top idea into a concrete research plan.
+
+1. Write the two-sentence pitch (Framework 10)
+2. Identify the core tension being resolved (Framework 3)
+3. Specify the abstraction level (Framework 2)
+4. List 3 concrete experiments that would validate the idea
+5. Anticipate the strongest objection and prepare a response
+6. Define a 2-week pilot that would provide signal on feasibility
+
+**Completion Checklist**:
+- [ ] Two-sentence pitch is clear and compelling
+- [ ] Problem is genuine (problem-first check passed)
+- [ ] Approach is justified (simplicity test passed)
+- [ ] At least one stakeholder clearly benefits
+- [ ] Core experiments are specified
+- [ ] Feasibility pilot is defined
+- [ ] Strongest objection has a response
+
+---
+
+## Framework Selection Guide
+
+Not sure which framework to start with? Use this decision guide:
+
+| Your Situation | Start With |
+|---------------|------------|
+| "I don't know what area to work in" | Tension Hunting (F3) → What Changed (F5) |
+| "I have a vague area but no specific idea" | Abstraction Ladder (F2) → Failure Analysis (F6) |
+| "I have an idea but I'm not sure it's good" | Explain-It Test (F10) → Simplicity Test (F7) |
+| "I have a good idea but need a fresh angle" | Cross-Pollination (F4) → Stakeholder Rotation (F8) |
+| "I want to combine existing work into something new" | Composition/Decomposition (F9) |
+| "I found a cool technique and want to apply it" | Problem-First Check (F1) → Stakeholder Rotation (F8) |
+| "I want to challenge conventional wisdom" | Failure Analysis (F6) → Simplicity Test (F7) |
+
+---
+
+## Common Pitfalls in Research Ideation
+
+| Pitfall | Symptom | Fix |
+|---------|---------|-----|
+| **Novelty without impact** | "No one has done X" but no one needs X | Apply Problem-First Check (F1) |
+| **Incremental by default** | Idea is +2% on a benchmark | Climb the Abstraction Ladder (F2) |
+| **Complexity worship** | Method has 8 components, each helping marginally | Apply Simplicity Test (F7) |
+| **Echo chamber** | All ideas come from reading the same 10 papers | Use Cross-Pollination (F4) |
+| **Stale assumptions** | "This was tried and didn't work" (5 years ago) | Apply What Changed (F5) |
+| **Single-perspective bias** | Only considering the ML engineer's view | Use Stakeholder Rotation (F8) |
+| **Premature convergence** | Committed to first idea without exploring alternatives | Run full Diverge phase |
+
+---
+
+## Usage Instructions for Agents
+
+When a researcher asks for help brainstorming research ideas:
+
+1. **Identify their starting point**: Are they exploring a new area, stuck on a current project, or evaluating an existing idea?
+2. **Select appropriate frameworks**: Use the Framework Selection Guide to pick 2-3 relevant lenses
+3. **Walk through frameworks interactively**: Apply each framework step-by-step, asking the researcher for domain-specific inputs
+4. **Generate candidates**: Aim for 10-20 raw ideas across frameworks
+5. **Filter and rank**: Apply the Converge phase filters to narrow to top 3-5
+6. **Refine the winner**: Help articulate the two-sentence pitch and define concrete next steps
+
+**Key Principles**:
+- Push for specificity—vague ideas ("improve efficiency") are not actionable
+- Challenge assumptions—ask "why?" at least three times
+- Maintain a written list of all candidates, even rejected ones (they may recombine later)
+- The researcher makes the final call on which ideas to pursue; the agent facilitates structured thinking

--- a/21-research-ideation/creative-thinking-for-research/SKILL.md
+++ b/21-research-ideation/creative-thinking-for-research/SKILL.md
@@ -1,0 +1,366 @@
+---
+name: creative-thinking-for-research
+description: Applies cognitive science frameworks for creative thinking to CS and AI research ideation. Use when seeking genuinely novel research directions by leveraging combinatorial creativity, analogical reasoning, constraint manipulation, and other empirically grounded creative strategies.
+version: 1.0.0
+author: Orchestra Research
+license: MIT
+tags: [Creative Thinking, Research Ideation, Analogical Reasoning, Problem Reformulation, Cognitive Science]
+dependencies: []
+---
+
+# Creative Thinking for Research
+
+Eight empirically grounded frameworks from cognitive science, applied to computer science and AI research. Unlike ad-hoc brainstorming, each framework here is backed by decades of creativity research — from Koestler's bisociation to Kauffman's adjacent possible. They target distinct cognitive operations: combining, reformulating, analogizing, constraining, inverting, abstracting, exploring boundaries, and holding contradictions.
+
+## When to Use This Skill
+
+- Generating genuinely novel ideas, not incremental extensions of prior work
+- Feeling trapped in a local optimum of thinking within a single subfield
+- Wanting to systematically apply creativity heuristics rather than waiting for inspiration
+- Preparing for a research retreat or PhD-level ideation session
+- Bridging between fields and seeking structural (not superficial) connections
+
+**Do NOT use this skill when**:
+- You need structured project-level brainstorming workflows (use `brainstorming-research-ideas`)
+- You have a well-defined problem and need execution help (use domain-specific skills)
+- You need a literature survey (use `scientific-skills:literature-review`)
+
+**Relationship to Brainstorm skill**: The brainstorm skill provides operational workflows (diverge → converge → refine) and practical filters. This skill provides the deeper cognitive engines that power creative leaps. Use them together: creative-thinking to generate raw insight, brainstorm to structure and evaluate it.
+
+---
+
+## Framework 1: Combinatorial Creativity (Bisociation)
+
+Novel ideas arise from combining existing concepts in unexpected ways. Arthur Koestler called this **bisociation** — connecting two previously unrelated frames of reference, as distinct from routine association within a single frame.
+
+**Why it works**: Meta-research consistently shows that breadth of knowledge is a precursor to creative output. People who read across disciplines produce more novel work. The combination itself is the creative act.
+
+**In CS Research**:
+- Biological evolution → optimization (genetic algorithms)
+- Game theory → networking (mechanism design for routing)
+- Statistical physics → machine learning (Boltzmann machines, energy-based models)
+- Linguistics → programming (type theory, formal grammars)
+
+**Systematic Bisociation Workflow**:
+
+1. **Select two domains** you have at least passing familiarity with
+2. **List core primitives** in each domain (5-10 fundamental concepts per domain)
+3. **Create a cross-product matrix**: row = concepts from Domain A, column = concepts from Domain B
+4. **For each cell**, ask: "What would it mean to apply A's concept to B's problem?"
+5. **Filter**: Which combinations produce a non-trivial, testable research question?
+6. **Validate structural depth**: Is the connection mechanistic or merely metaphorical?
+
+**Cross-Product Example**:
+
+| | Caching | Load Balancing | Fault Tolerance |
+|---|---------|---------------|-----------------|
+| **Natural Selection** | Evict least-fit entries | Adaptive allocation via fitness | Population-level redundancy |
+| **Immune Memory** | Learned threat signatures | Distributed detection | Self/non-self discrimination |
+| **Symbiosis** | Cooperative prefetching | Mutualistic resource sharing | Co-dependent resilience |
+
+**Quality Test**: A strong bisociation is not a surface metaphor ("the network is like a brain") but a structural mapping where the mechanism transfers ("attention mechanisms implement a form of selective gating analogous to cognitive attention filtering").
+
+**Self-Check**:
+- [ ] Is the connection structural (mechanisms map) or merely verbal (labels map)?
+- [ ] Does the combination generate testable predictions?
+- [ ] Would an expert in both fields find the connection non-obvious but sound?
+
+---
+
+## Framework 2: Problem Reformulation (Representational Change)
+
+Gestalt psychologists identified that breakthroughs often come not from solving the problem as stated, but from **re-representing the problem itself**. Kaplan and Simon's work on insight shows that changing the problem space — the constraints, the abstraction level, the formalism — is often where creativity lives.
+
+**The Key Shift**: From "How do I solve this problem?" to "Am I even thinking about this problem correctly?"
+
+**Reformulation Strategies**:
+
+| Strategy | Example |
+|----------|---------|
+| **Change the objective** | "Make the algorithm faster" → "Eliminate the need for this computation" |
+| **Change the formalism** | Graph problem → linear algebra problem (spectral methods) |
+| **Change the granularity** | Per-token prediction → per-span prediction |
+| **Change the agent** | "How should the model learn?" → "How should the data teach?" (curriculum learning) |
+| **Change the timescale** | Real-time optimization → amortized inference |
+| **Invert the direction** | Forward simulation → inverse problem (learning from observations) |
+
+**Workflow**:
+
+1. State your current problem in one sentence
+2. Identify the **hidden assumptions** in that statement:
+   - What formalism are you using? (Could you use a different one?)
+   - What is the objective? (Is it the right objective?)
+   - What level of granularity? (Could you go coarser or finer?)
+   - Who is the agent? (Could you shift perspective?)
+3. For each assumption, **generate the alternative**: "What if [opposite assumption]?"
+4. For each alternative, ask: "Does this reformulation make the problem easier, harder, or different in a useful way?"
+5. A reformulation that makes a hard problem easy is often a publishable insight on its own
+
+**Classic CS Examples**:
+- **PageRank**: Reformulated "find important web pages" from content analysis to graph eigenvalue problem
+- **Dropout**: Reformulated "prevent overfitting" from regularization to approximate ensemble
+- **Attention**: Reformulated "handle long sequences" from remembering everything to selectively querying
+
+---
+
+## Framework 3: Analogical Reasoning (Structure-Mapping)
+
+Dedre Gentner's **structure-mapping theory** and Kevin Dunbar's studies of real scientists show that analogy is the core engine of scientific creativity. The critical finding: surface-level analogies are common but weak; **structural or relational analogies** — where the deep causal/relational structure maps across domains — produce the most powerful insights.
+
+**Dunbar's Finding**: In the most successful labs, analogies from distant domains drove the most important discoveries. Nearby analogies refined ideas; distant analogies generated them.
+
+**Levels of Analogical Depth**:
+
+| Level | Description | Value | Example |
+|-------|-------------|-------|---------|
+| **Surface** | Things look similar | Low | "A neural network is like a brain" |
+| **Relational** | Relationships between entities match | Medium | "Attention allocation in models parallels resource allocation in economics" |
+| **Structural** | Deep causal mechanisms map | High | "Diffusion models reverse a thermodynamic process; the math of non-equilibrium stat-mech directly applies" |
+
+**Structure-Mapping Workflow**:
+
+1. **Describe your problem** using only relational/causal language (strip domain-specific nouns)
+   - Bad: "We need to improve transformer attention efficiency"
+   - Good: "We have a system that must selectively aggregate information from a large set, where relevance is context-dependent and the cost scales quadratically with set size"
+2. **Search for structural matches**: What other systems selectively aggregate from large sets?
+   - Database query optimization, visual attention in neuroscience, information retrieval, resource allocation
+3. **Pick the most distant match** with genuine structural fidelity
+4. **Map the solution mechanism**: How does the source domain solve this?
+5. **Transfer and adapt**: What changes when you bring that mechanism into your domain?
+6. **Generate predictions**: The analogy should tell you something you didn't already know
+
+**Validation Checklist**:
+- [ ] Does the mapping preserve causal/relational structure (not just labels)?
+- [ ] Can I identify at least one prediction the analogy makes in my domain?
+- [ ] Would an expert in the source domain confirm the mechanism is correctly understood?
+- [ ] Is the analogy non-obvious to my target audience?
+
+---
+
+## Framework 4: Constraint Manipulation (Boden's Framework)
+
+Margaret Boden's framework distinguishes three forms of creativity based on how they interact with constraints:
+
+| Type | Operation | CS Example |
+|------|-----------|------------|
+| **Exploratory** | Search within the existing conceptual space | Hyperparameter tuning, architecture search within a fixed paradigm |
+| **Combinational** | Combine elements from different spaces | Multi-task learning, neuro-symbolic methods |
+| **Transformational** | Change the rules of the space itself | Dropping the assumption that training requires labels (self-supervised learning) |
+
+**Transformational creativity is the rarest and highest-impact.** It happens when you change what is even considered a valid solution.
+
+**Constraint Analysis Workflow**:
+
+1. **List the constraints** of your current approach (5-10 constraints):
+   - Computational: "Must fit in GPU memory"
+   - Methodological: "Requires labeled data"
+   - Architectural: "Uses fixed-length context"
+   - Evaluative: "Measured by accuracy on benchmark X"
+2. **Classify each constraint**:
+   - **Hard**: Physically or logically necessary (cannot violate)
+   - **Soft**: Convention or historical accident (can question)
+   - **Hidden**: Not stated but implicitly assumed (most fertile for innovation)
+3. **For each soft/hidden constraint**, ask:
+   - What if we relaxed it? (streaming algorithms from relaxing "fits in memory")
+   - What if we tightened it? (efficiency research from tightening compute budgets)
+   - What if we replaced it with a different constraint entirely?
+4. **The most productive move** is often exposing and dropping a hidden constraint
+
+**Classic Examples of Constraint Transformation**:
+- "Data must fit in memory" → dropped → streaming algorithms, external memory
+- "Training requires human labels" → dropped → self-supervised learning
+- "Models must be deterministic" → dropped → variational methods, diffusion
+- "Inference must happen in one pass" → dropped → iterative refinement, chain-of-thought
+
+---
+
+## Framework 5: Negation and Inversion
+
+Take a core assumption in your field and negate it. This is formalized in De Bono's lateral thinking and the **TRIZ methodology** from engineering.
+
+**The Pattern**: "What if [widely held assumption] is wrong, unnecessary, or invertible?"
+
+**Systematic Negation Workflow**:
+
+1. **List 5-10 core assumptions** in your subfield (the things "everyone knows")
+2. **Negate each one** and ask: What system would you build?
+3. **Evaluate each negation**:
+   - Incoherent → discard
+   - Already explored → check if conditions have changed (see brainstorm skill, Framework 5)
+   - Unexplored and coherent → potential research direction
+
+**Negation Hall of Fame in CS**:
+
+| Assumption | Negation | Result |
+|-----------|----------|--------|
+| "We need strong consistency" | What if we don't? | Eventual consistency, CRDTs |
+| "We need exact answers" | What if approximate is fine? | Sketches, LSH, approximate nearest neighbors |
+| "Labels are necessary" | What if we learn without them? | Self-supervised learning, contrastive methods |
+| "More parameters = more compute" | What if we don't use all parameters? | Mixture of Experts, sparse models |
+| "Training and inference are separate" | What if the model keeps learning? | Online learning, test-time training |
+| "Errors must be prevented" | What if we embrace and correct them? | Speculative decoding, self-correction |
+
+**TRIZ-Inspired Principles for CS**:
+
+| TRIZ Principle | CS Application |
+|---------------|----------------|
+| **Inversion** | Reverse the process (generative vs. discriminative) |
+| **Segmentation** | Break monolithic into modular (microservices, mixture of experts) |
+| **Merging** | Combine separate steps (end-to-end learning) |
+| **Universality** | One component serves multiple functions (multi-task models) |
+| **Nesting** | Place one system inside another (meta-learning) |
+| **Dynamization** | Make static things adaptive (dynamic architectures, adaptive computation) |
+
+---
+
+## Framework 6: Abstraction and Generalization Laddering
+
+Moving up and down the abstraction ladder is a fundamental creative act. Polya's heuristics formalize this: *"Can you solve a more general problem? A more specific one? An analogous one?"*
+
+**Three Moves**:
+
+| Move | Question | Outcome |
+|------|----------|---------|
+| **Generalize** | "Is my solution a special case of something broader?" | Framework papers, unifying theories |
+| **Specialize** | "What happens when I add extreme constraints?" | Niche applications, surprising edge cases |
+| **Analogize** | "Where else does this abstract pattern appear?" | Cross-domain transfer (see Framework 3) |
+
+**Generalization Workflow**:
+1. State your specific result
+2. Replace each specific element with a variable: "ResNet works for ImageNet" → "Architecture X works for distribution Y"
+3. Ask: Under what conditions does this hold? What is the general principle?
+4. If the general principle is novel → that is the contribution
+
+**Specialization Workflow**:
+1. Take a general method
+2. Add extreme constraints: tiny data, huge dimensionality, adversarial inputs, real-time requirements
+3. Ask: Does the method still work? If not, why not?
+4. The failure case often reveals the method's true assumptions
+
+**When to Generalize vs. Specialize**:
+- Generalize when you have results but no explanation
+- Specialize when you have theory but no grounding
+- Analogize when you are stuck in either direction
+
+---
+
+## Framework 7: The Adjacent Possible (Kauffman / Johnson)
+
+Stuart Kauffman's concept, popularized by Steven Johnson: innovation happens at the boundary of what is currently reachable — the **adjacent possible**. New ideas become thinkable once their prerequisites exist. This explains why simultaneous independent discovery is so common — multiple people reach the same boundary.
+
+**Practical Implication**: Map what has recently become possible and explore the space those enablers open.
+
+**Adjacent Possible Mapping Workflow**:
+
+1. **List recent enablers** (last 1-3 years):
+   - New hardware capabilities (longer context, faster inference, new accelerators)
+   - New datasets or benchmarks
+   - New open-source tools or frameworks
+   - New theoretical results
+   - New regulatory or social conditions
+2. **For each enabler, ask**: "What was previously impossible or impractical that this now permits?"
+3. **Combine enablers**: The most powerful adjacent possibles arise from the intersection of multiple new enablers
+4. **Check for competition**: If many people can see the same adjacent possible, speed or a unique angle matters
+
+**Current Adjacent Possibles (2025-2026)**:
+
+| Enabler | Newly Possible |
+|---------|---------------|
+| 1M+ token context windows | Full-codebase reasoning, book-length analysis |
+| Inference cost drops (100x in 2 years) | Real-time agentic loops, always-on AI assistants |
+| Open-weight models at GPT-4 level | Reproducible research on frontier capabilities |
+| Multimodal models (vision + language + audio) | Unified perception-reasoning systems |
+| Synthetic data at scale | Training data for domains with no natural data |
+| Tool-using models | Research automation, self-improving systems |
+
+**Timing Signal**: If your idea requires technology that doesn't exist yet, it's beyond the adjacent possible — park it. If your idea could have been done 5 years ago, someone probably did — check the literature. The sweet spot is ideas that became feasible in the last 6-18 months.
+
+---
+
+## Framework 8: Janusian and Dialectical Thinking
+
+Albert Rothenberg's studies of eminent creators found that **holding two contradictory ideas simultaneously** is a hallmark of creative thinking. Named after Janus, the two-faced Roman god, this mode of thinking doesn't resolve contradictions by choosing a side — it generates new frameworks that transcend the opposition.
+
+**In CS**: The most influential results often emerge from tensions previously thought irreconcilable.
+
+| Contradiction | Resolution | Impact |
+|--------------|------------|--------|
+| Consistency AND Availability (distributed systems) | CAP theorem: formalized the trade-off, then Raft/CRDTs found practical middle grounds | Foundation of distributed systems theory |
+| Security AND Usability | Zero-knowledge proofs: prove knowledge without revealing it | Enabled private computation |
+| Expressiveness AND Tractability | Probabilistic programming: express complex models, automate inference | New programming paradigm |
+| Memorization AND Generalization | Grokking: models memorize first, then generalize with more training | New understanding of learning dynamics |
+| Compression AND Quality | Neural codecs that compress beyond information-theoretic limits via learned priors | Redefined compression research |
+
+**Dialectical Thinking Workflow**:
+
+1. **Identify a binary** in your field: A vs. B (two approaches, goals, or paradigms treated as opposites)
+2. **Resist choosing a side**. Instead ask:
+   - "What would a system look like that achieves both A and B?"
+   - "Under what conditions is the A-B trade-off not fundamental?"
+   - "Is the opposition an artifact of how we formalized the problem?"
+3. **Seek synthesis**: The resolution often requires a new abstraction that reframes the relationship
+4. **Test the synthesis**: Can you demonstrate empirically that both goals are achievable?
+
+**Self-Check**:
+- [ ] Am I holding the contradiction genuinely (not prematurely resolving it)?
+- [ ] Is the synthesis a new idea, not just a compromise (splitting the difference)?
+- [ ] Does the resolution change how people think about the problem, not just the solution?
+
+---
+
+## Combining Frameworks: A Creative Thinking Protocol
+
+These frameworks are most powerful in combination. Here is a systematic protocol for a deep creative thinking session:
+
+### Phase 1: Map the Space (15 min)
+1. **Constraint Manipulation** (F4): List all constraints of the current paradigm. Mark which are hard, soft, hidden.
+2. **Adjacent Possible** (F7): List recent enablers that change the feasibility landscape.
+
+### Phase 2: Generate Disruptions (30 min)
+3. **Negation** (F5): Negate 3 soft/hidden constraints. What systems emerge?
+4. **Bisociation** (F1): Pick a distant field and create a cross-product matrix with your domain.
+5. **Problem Reformulation** (F2): Restate your problem 3 different ways (change objective, formalism, agent).
+
+### Phase 3: Deepen Promising Leads (30 min)
+6. **Analogical Reasoning** (F3): For each promising idea, find a structural analogy and extract predictions.
+7. **Abstraction Laddering** (F6): Move each idea up (generalize) and down (specialize).
+8. **Janusian Thinking** (F8): Identify any tensions. Can you synthesize rather than choose?
+
+### Phase 4: Evaluate (15 min)
+Apply the two-sentence test (from the brainstorm skill):
+> "**[Domain] currently struggles with [problem] because [reason].** We [approach] by [mechanism], which works because [insight]."
+
+Any idea that survives all four phases and passes the two-sentence test is worth pursuing.
+
+---
+
+## Common Creative Blocks and Unblocking Strategies
+
+| Block | Symptom | Framework to Apply |
+|-------|---------|-------------------|
+| **Fixation** | Cannot stop thinking about the problem one way | Problem Reformulation (F2) — force a different representation |
+| **Tunnel vision** | All ideas come from the same subfield | Bisociation (F1) or Analogical Reasoning (F3) — import from elsewhere |
+| **Self-censoring** | Dismissing ideas as "too weird" before exploring | Negation (F5) — weird is the point; evaluate after generating |
+| **Incrementalism** | Every idea is "+2% on benchmark X" | Constraint Manipulation (F4) — change the rules, not the parameters |
+| **Analysis paralysis** | Too many options, cannot commit | Adjacent Possible (F7) — what is feasible right now? |
+| **False dichotomy** | Stuck choosing between two approaches | Janusian Thinking (F8) — seek synthesis, not selection |
+
+---
+
+## Usage Instructions for Agents
+
+When a researcher asks for help with creative thinking or novel ideation:
+
+1. **Assess the block**: What kind of thinking are they stuck in? (See Common Creative Blocks table)
+2. **Select 2-3 frameworks** based on the block type
+3. **Walk through each framework interactively**, asking the researcher to supply domain-specific content
+4. **Push for structural depth**: If an analogy or combination is surface-level, probe deeper
+5. **Maintain a running list** of all generated ideas, even unusual ones
+6. **Apply the two-sentence test** to candidates that survive exploration
+7. **Hand off to the brainstorm skill** for systematic evaluation (diverge → converge → refine)
+
+**Key Principles**:
+- Generative mode first, evaluative mode second — do not filter prematurely
+- Distant analogies are more valuable than nearby ones, but require more validation
+- The researcher's domain expertise is essential — the agent provides the cognitive scaffolding, not the domain knowledge
+- Encourage the researcher to sit with contradictions rather than resolve them quickly

--- a/README.md
+++ b/README.md
@@ -17,12 +17,12 @@
 
 <div align="center">
 
-### **83 Skills Powering AI Research in 2026**
+### **85 Skills Powering AI Research in 2026**
 
 </div>
 
 <details>
-<summary><b>View All 20 Categories</b></summary>
+<summary><b>View All 21 Categories</b></summary>
 
 <div align="center">
 
@@ -34,7 +34,7 @@
 | **Safety & Alignment** (4) | **Agents** (4) | **RAG** (5) |
 | **Multimodal** (7) | **Prompt Engineering** (4) | **MLOps** (3) |
 | **Observability** (2) | **Infrastructure** (3) | **Mech Interp** (4) |
-| **Emerging Techniques** (6) | **ML Paper Writing** (1) | |
+| **Emerging Techniques** (6) | **ML Paper Writing** (1) | **Ideation** (2) |
 
 </div>
 
@@ -71,7 +71,7 @@ Modern AI research requires mastering dozens of specialized tools and frameworks
 AI Researchers spend more time debugging infrastructure than testing hypotheses—slowing the pace of scientific discovery. 
 We provide a comprehensive library of expert-level research engineering skills that enable AI agents to autonomously implement and execute different stages of AI research experiments—from data preparation and model training to evaluation and deployment.
   - Specialized Expertise - Each skill provides deep, production-ready knowledge of a specific framework (Megatron-LM, vLLM, TRL, etc.)
-  - End-to-End Coverage - 83 skills spanning the full AI research lifecycle, from model architecture to deployment
+  - End-to-End Coverage - 85 skills spanning the full AI research lifecycle, from model architecture to deployment
   - Research-Grade Quality - Documentation sourced from official repos, real GitHub issues, and battle-tested production workflows
 
 ## Available AI Research Engineering Skills
@@ -116,7 +116,7 @@ Install skill categories directly using the **Claude Code CLI**:
 # Add the marketplace
 /plugin marketplace add orchestra-research/AI-research-SKILLs
 
-# Install by category (20 categories available)
+# Install by category (21 categories available)
 /plugin install fine-tuning@ai-research-skills        # Axolotl, LLaMA-Factory, PEFT, Unsloth
 /plugin install post-training@ai-research-skills      # TRL, GRPO, OpenRLHF, SimPO, verl, slime, miles, torchforge
 /plugin install inference-serving@ai-research-skills  # vLLM, TensorRT-LLM, llama.cpp, SGLang
@@ -126,7 +126,7 @@ Install skill categories directly using the **Claude Code CLI**:
 
 </details>
 
-### All 20 Categories (83 Skills)
+### All 21 Categories (85 Skills)
 
 | Category | Skills | Included |
 |----------|--------|----------|
@@ -150,9 +150,10 @@ Install skill categories directly using the **Claude Code CLI**:
 | Multimodal | 7 | CLIP, Whisper, LLaVA, BLIP-2, SAM, Stable Diffusion, AudioCraft |
 | Emerging | 6 | MoE, Model Merging, Long Context, Speculative Decoding, Distillation, Pruning |
 | ML Paper Writing | 1 | ML Paper Writing (LaTeX templates, citation verification) |
+| Ideation | 2 | Research Brainstorming, Creative Thinking |
 
 <details>
-<summary><b>View All 83 Skills in Details</b></summary>
+<summary><b>View All 85 Skills in Details</b></summary>
 
 ### 🏗️ Model Architecture (5 skills)
 - **[LitGPT](01-model-architecture/litgpt/)** - Lightning AI's 20+ clean LLM implementations with production training recipes (462 lines + 4 refs)
@@ -278,12 +279,16 @@ Install skill categories directly using the **Claude Code CLI**:
 ### 📝 ML Paper Writing (1 skill)
 - **[ML Paper Writing](20-ml-paper-writing/)** - Write publication-ready papers for NeurIPS, ICML, ICLR, ACL, AAAI, COLM with LaTeX templates, citation verification, and writing best practices (532 lines + 5 refs)
 
+### 💡 Ideation (2 skills)
+- **[Research Brainstorming](21-research-ideation/brainstorming-research-ideas/)** - Structured ideation frameworks for discovering high-impact research directions with 10 complementary lenses (384 lines)
+- **[Creative Thinking](21-research-ideation/creative-thinking-for-research/)** - Cognitive science frameworks (bisociation, structure-mapping, constraint manipulation) for genuinely novel research ideas (366 lines)
+
 
 </details>
 
 ## Demos
 
-All 83 skills in this repo are automatically synced to [Orchestra Research](https://www.orchestra-research.com/research-skills), where you can add them to your projects with one click and use them with AI research agents.
+All 85 skills in this repo are automatically synced to [Orchestra Research](https://www.orchestra-research.com/research-skills), where you can add them to your projects with one click and use them with AI research agents.
 
 **See skills in action → [demos/](demos/README.md)**
 
@@ -345,12 +350,12 @@ We're building towards 80 comprehensive skills across the full AI research lifec
 
 | Metric | Current | Target |
 |--------|---------|--------|
-| **Skills** | **83** (high-quality, standardized YAML) | 80 ✅ |
+| **Skills** | **85** (high-quality, standardized YAML) | 80 ✅ |
 | **Avg Lines/Skill** | **420 lines** (focused + progressive disclosure) | 200-600 lines |
 | **Documentation** | **~130,000 lines** total (SKILL.md + references) | 100,000+ lines |
 | **Gold Standard Skills** | **65** with comprehensive references | 50+ |
 | **Contributors** | 1 | 100+ |
-| **Coverage** | Architecture, Tokenization, Fine-Tuning, Mechanistic Interpretability, Data Processing, Post-Training, Safety, Distributed, Optimization, Evaluation, Infrastructure, Inference, Agents, RAG, Multimodal, Prompt Engineering, MLOps, Observability | Full Lifecycle ✅ |
+| **Coverage** | Architecture, Tokenization, Fine-Tuning, Mechanistic Interpretability, Data Processing, Post-Training, Safety, Distributed, Optimization, Evaluation, Infrastructure, Inference, Agents, RAG, Multimodal, Prompt Engineering, MLOps, Observability, ML Paper Writing, Ideation | Full Lifecycle ✅ |
 
 **Recent Progress**: npm package `@orchestra-research/ai-research-skills` for one-command installation across all coding agents
 
@@ -388,6 +393,7 @@ claude-ai-research-skills/
 ├── 18-multimodal/               (7 skills ✓ - CLIP, Whisper, LLaVA, Stable Diffusion, SAM, BLIP-2, AudioCraft)
 ├── 19-emerging-techniques/      (6 skills ✓ - MoE, Model Merging, Long Context, Speculative Decoding, Distillation, Pruning)
 ├── 20-ml-paper-writing/         (1 skill ✓ - ML Paper Writing with LaTeX templates)
+├── 21-research-ideation/                 (2 skills ✓ - Research Brainstorming, Creative Thinking)
 └── packages/ai-research-skills/ (npm package for one-command installation)
 ```
 

--- a/packages/ai-research-skills/package-lock.json
+++ b/packages/ai-research-skills/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchestra-research/ai-research-skills",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchestra-research/ai-research-skills",
-      "version": "1.3.6",
+      "version": "1.3.7",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/packages/ai-research-skills/package.json
+++ b/packages/ai-research-skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orchestra-research/ai-research-skills",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "description": "Install AI research engineering skills to your coding agents (Claude Code, OpenCode, Cursor, Gemini CLI, and more)",
   "main": "src/index.js",
   "bin": {

--- a/packages/ai-research-skills/src/installer.js
+++ b/packages/ai-research-skills/src/installer.js
@@ -400,6 +400,7 @@ export function getAllCategoryIds() {
     '18-multimodal',
     '19-emerging-techniques',
     '20-ml-paper-writing',
+    '21-research-ideation',
   ];
 }
 


### PR DESCRIPTION
## Summary
- Adds **21-research-ideation/** as the 21st skill category with 2 new skills:
  - **brainstorming-research-ideas** (384 lines): 10 structured ideation frameworks for discovering high-impact research directions
  - **creative-thinking-for-research** (366 lines): 8 cognitive science frameworks (bisociation, structure-mapping, constraint manipulation, Janusian thinking)
- Updates README (skill count 83→85, category count 20→21, tables, repo structure)
- Updates marketplace.json with new `ideation` plugin entry
- Adds `21-research-ideation` to npm installer category list
- Bumps npm package v1.3.6 → v1.3.7

## Test plan
- [ ] Verify SKILL.md YAML frontmatter parses correctly for both skills
- [ ] Verify `npx @orchestra-research/ai-research-skills` lists the new Ideation category
- [ ] Verify marketplace sync picks up both skills on merge to main
- [ ] Confirm README renders correctly on GitHub (tables, links, collapsible sections)

🤖 Generated with [Claude Code](https://claude.com/claude-code)