### PR TITLE
feat(agents): add Qoder to supported agents list

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ This installs all 98 skills, loads the **autoresearch** orchestration layer, and
 <details>
 <summary><b>What the installer does</b></summary>
 
-- **Auto-detects** your installed coding agents (Claude Code, Hermes Agent, OpenCode, Cursor, Gemini CLI, etc.)
+- **Auto-detects** your installed coding agents (Claude Code, Hermes Agent, OpenCode, Qoder, Cursor, Gemini CLI, etc.)
 - **Installs** skills to `~/.orchestra/skills/` with symlinks to each agent (falls back to copy on Windows)
 - **Offers** everything, quickstart bundle, by category, or individual skills
 - **Updates** installed skills with latest versions
@@ -543,7 +543,7 @@ We welcome contributions from the AI research community! See [CONTRIBUTING.md](C
 - 📄 **Two demo papers produced by autoresearch**: [Norm Heterogeneity → LoRA Brittleness](demos/autoresearch-norm-heterogeneity/) and [RL Algorithm Brain Scan](demos/autoresearch-rl-brain-scan/)
 - 🚀 WELCOME.md for cold-start agent bootstrap — one URL to go from zero to autonomous research
 - 📦 npm v1.4.x with Windows symlink fallback, all 22 categories installable
-- 🤖 **Supported agents**: Claude Code, Hermes Agent, OpenCode, OpenClaw, Cursor, Codex, Gemini CLI, Qwen Code
+- 🤖 **Supported agents**: Claude Code, Hermes Agent, OpenCode, OpenClaw, Qoder, Cursor, Codex, Gemini CLI, Qwen Code
 - 📊 **87 total skills** across **22 categories** — complete research lifecycle coverage
 
 </details>

--- a/packages/ai-research-skills/src/agents.js
+++ b/packages/ai-research-skills/src/agents.js
@@ -84,6 +84,14 @@ export const SUPPORTED_AGENTS = [
     localConfigDir: '.hermes',
     localSkillsDir: 'skills',
   },
+  {
+    id: 'qoder',
+    name: 'Qoder',
+    configDir: '.qoder',
+    skillsDir: 'skills',
+    localConfigDir: '.qoder',
+    localSkillsDir: 'skills',
+  },
 ];
 
 /**


### PR DESCRIPTION
## Summary

Add Qoder as a natively supported agent in `packages/ai-research-skills/src/agents.js`, following the same ~10-line entry pattern as all other supported agents.

## Motivation

Qoder loads skills from `.qoder/skills/` (both global and project-local). Rather than maintaining standalone install-guide documentation (as originally proposed), this PR follows the reviewer's suggestion to add a native `agents.js` entry — giving Qoder users `npx` install and auto-update for free.

## Changes

| File | Change |
|------|--------|
| `packages/ai-research-skills/src/agents.js` | Add Qoder agent config (`configDir: '.qoder'`, `skillsDir: 'skills'`) |
| `README.md` | Add Qoder to "Supported agents" list |

## How It Works

After this change, running `npx @orchestra-research/ai-research-skills` will:
1. Auto-detect Qoder (checks for `~/.qoder/` directory)
2. Install/symlink all 98 skills to `~/.qoder/skills/`
3. Support `npx ... update` for automatic skill updates

No standalone documentation needed — identical to how Claude Code, Cursor, Codex, and all other agents are supported.
