### PR TITLE
fix: correct category skill counts and listings in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,12 +10,12 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository Architecture
 
-### Directory Structure (86 Skills Across 22 Categories)
+### Directory Structure (95 Skills Across 22 Categories)
 
 Skills are organized into numbered categories representing the AI research lifecycle:
 
 - `0-autoresearch-skill/` - **Autonomous research orchestration** (1 skill: Autoresearch — central layer that manages the full lifecycle and routes to all other skills)
-- `01-model-architecture/` - Model architectures (5 skills: Megatron-Core, LitGPT, Mamba, RWKV, NanoGPT)
+- `01-model-architecture/` - Model architectures (5 skills: TorchTitan, LitGPT, Mamba, RWKV, NanoGPT)
 - `02-tokenization/` - Tokenizers (2 skills: HuggingFace Tokenizers, SentencePiece)
 - `03-fine-tuning/` - Fine-tuning frameworks (4 skills: Axolotl, LLaMA-Factory, Unsloth, PEFT)
 - `04-mechanistic-interpretability/` - Interpretability tools (4 skills: TransformerLens, SAELens, NNsight, Pyvene)
@@ -24,17 +24,17 @@ Skills are organized into numbered categories representing the AI research lifec
 - `07-safety-alignment/` - Safety and guardrails (4 skills: Constitutional AI, LlamaGuard, NeMo Guardrails, Prompt Guard)
 - `08-distributed-training/` - Distributed systems (6 skills: Megatron-Core, DeepSpeed, FSDP, Accelerate, PyTorch Lightning, Ray Train)
 - `09-infrastructure/` - Cloud compute (3 skills: Modal, SkyPilot, Lambda Labs)
-- `10-optimization/` - Optimization techniques (6 skills: Flash Attention, bitsandbytes, GPTQ, AWQ, HQQ, GGUF)
+- `10-optimization/` - Optimization techniques (7 skills: Flash Attention, bitsandbytes, GPTQ, AWQ, HQQ, GGUF, ML Training Recipes)
 - `11-evaluation/` - Benchmarking (3 skills: lm-evaluation-harness, BigCode, NeMo Evaluator)
 - `12-inference-serving/` - Inference engines (4 skills: vLLM, TensorRT-LLM, llama.cpp, SGLang)
-- `13-mlops/` - Experiment tracking (3 skills: Weights & Biases, MLflow, TensorBoard)
-- `14-agents/` - Agent frameworks (4 skills: LangChain, LlamaIndex, CrewAI, AutoGPT)
+- `13-mlops/` - Experiment tracking (4 skills: Weights & Biases, MLflow, TensorBoard, SwanLab)
+- `14-agents/` - Agent frameworks (5 skills: LangChain, LlamaIndex, CrewAI, AutoGPT, A-Evolve)
 - `15-rag/` - Retrieval-augmented generation (5 skills: Chroma, FAISS, Sentence Transformers, Pinecone, Qdrant)
 - `16-prompt-engineering/` - Structured output (4 skills: DSPy, Instructor, Guidance, Outlines)
 - `17-observability/` - LLM observability (2 skills: LangSmith, Phoenix)
-- `18-multimodal/` - Vision and speech (7 skills: CLIP, Whisper, LLaVA, Stable Diffusion, SAM, BLIP-2, AudioCraft)
+- `18-multimodal/` - Vision and speech (10 skills: CLIP, Whisper, LLaVA, Stable Diffusion, SAM, BLIP-2, AudioCraft, Cosmos Policy, OpenPI, OpenVLA-OFT)
 - `19-emerging-techniques/` - Advanced methods (6 skills: MoE Training, Model Merging, Long Context, Speculative Decoding, Knowledge Distillation, Model Pruning)
-- `20-ml-paper-writing/` - Paper writing (1 skill: ML Paper Writing with LaTeX templates for NeurIPS, ICML, ICLR, ACL, AAAI, COLM)
+- `20-ml-paper-writing/` - Paper writing (4 skills: ML Paper Writing, Systems Paper Writing, Academic Plotting, Presenting Conference Talks)
 - `21-research-ideation/` - Ideation (2 skills: Research Brainstorming, Creative Thinking)
 
 ### Skill File Structure


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## What this fixes

CLAUDE.md's `Directory Structure` section contains stale skill listings that don't match the actual files on disk. Contributors reading the project overview will miss 9 skills and see one wrong skill name. This PR corrects all 7 discrepancies found by the audit.

### Specific corrections

| Category | Before | After | Issue |
|----------|--------|-------|-------|
| `01-model-architecture/` | Megatron-Core | **TorchTitan** | `torchtitan/SKILL.md` exists; Megatron-Core lives in `08-distributed-training/` |
| `10-optimization/` | 6 skills | **7 skills** | `ml-training-recipes/SKILL.md` exists but was not listed |
| `13-mlops/` | 3 skills (W&B, MLflow, TensorBoard) | **4 skills** | `swanlab/SKILL.md` exists but was not listed |
| `14-agents/` | 4 skills (LangChain, LlamaIndex, CrewAI, AutoGPT) | **5 skills** | `a-evolve/SKILL.md` exists but was not listed |
| `18-multimodal/` | 7 skills | **10 skills** | `cosmos-policy/`, `openpi/`, `openvla-oft/` SKILL.md files exist but were not listed |
| `20-ml-paper-writing/` | 1 skill | **4 skills** | `systems-paper-writing/`, `academic-plotting/`, `presenting-conference-talks/` exist but were not listed |
| Header | 86 Skills | **95 Skills** | Actual SKILL.md count is 95; header was last updated before category expansions |

## Why it matters

The CLAUDE.md is the primary orientation document for Claude Code agents working in this repo. When an agent reads the category inventory, it forms a mental model of what skills exist. Stale listings mean:
- New contributors won't know SwanLab, A-Evolve, ML Training Recipes, and the newer multimodal/paper-writing skills are maintained
- Automated tooling that parses category counts will compute wrong totals
- The "Megatron-Core" entry in `01-model-architecture/` is actively wrong — that skill belongs to `08-distributed-training/`

## No behavioural changes

This PR only updates documentation comments in CLAUDE.md. No skill files, scripts, or configs are touched.