### PR TITLE
fix(security): pin npm dependency versions to exact ranges

### DIFF
--- a/packages/ai-research-skills/package.json
+++ b/packages/ai-research-skills/package.json
@@ -42,8 +42,8 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "chalk": "^5.3.0",
-    "inquirer": "^9.2.12",
-    "ora": "^8.0.1"
+    "chalk": "5.3.0",
+    "inquirer": "9.2.12",
+    "ora": "8.0.1"
   }
 }


### PR DESCRIPTION
> **Automated audit**: This PR was generated by [NLPM](https://github.com/xiaolai/nlpm-for-claude), a natural language programming linter, running via [claude-code-action](https://github.com/anthropics/claude-code-action). Please evaluate the diff on its merits.

## What this fixes

`packages/ai-research-skills/package.json` uses caret (`^`) version ranges for all three dependencies:

```json
"chalk": "^5.3.0",
"inquirer": "^9.2.12",
"ora": "^8.0.1"
```

Caret ranges allow `npm install` to pull any compatible minor or patch release automatically — without an explicit review step. For a published CLI tool that runs `execSync` and writes to `~/.orchestra/`, predictable dependency behaviour is important.

**Severity**: Low (NLPM audit finding #4).

## The fix

Pin to the exact versions already in use:

```json
"chalk": "5.3.0",
"inquirer": "9.2.12",
"ora": "8.0.1"
```

Upgrades remain easy — just bump the pinned version and commit intentionally. This is also compatible with the repo's OIDC-signed `npm publish` workflow (Sigstore provenance is most meaningful when the published artifact is fully deterministic).

## No functional changes

The installed versions are unchanged from what `package-lock.json` already resolves to. Only the resolution policy changes.