### PR TITLE
Fix skill/category inventory counts (98/23) + add drift guard

### DIFF
--- a/.github/workflows/check-inventory.yml
+++ b/.github/workflows/check-inventory.yml
@@ -1,0 +1,31 @@
+name: Check Inventory Counts
+
+# Fails if the documented skill/category counts drift from the actual repo
+# contents. See scripts/check-inventory.sh and issue #54.
+
+on:
+  pull_request:
+    paths:
+      - '**/SKILL.md'
+      - 'CLAUDE.md'
+      - 'CONTRIBUTING.md'
+      - 'README.md'
+      - 'WELCOME.md'
+      - 'packages/ai-research-skills/README.md'
+      - 'scripts/check-inventory.sh'
+      - '.github/workflows/check-inventory.yml'
+  push:
+    branches: [main]
+    paths:
+      - '**/SKILL.md'
+      - 'CLAUDE.md'
+      - 'packages/ai-research-skills/README.md'
+  workflow_dispatch:
+
+jobs:
+  check-inventory:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify documented skill/category counts
+        run: bash scripts/check-inventory.sh

--- a/.github/workflows/sync-skills.yml
+++ b/.github/workflows/sync-skills.yml
@@ -117,10 +117,18 @@ jobs:
             # Copy all contents of skill directory (SKILL.md, references/, scripts/, assets/, etc.)
             cp -r "$SKILL_PATH"/* "$SKILL_DIR/" 2>/dev/null || true
 
-            # Create zip file (exclude hidden files and .gitkeep)
+            # Prune build artifacts that may have leaked into a skill folder
+            # before zipping (these are not hidden, so the -x globs below miss
+            # them and they can blow past the marketplace's 200-file limit).
+            find "$SKILL_DIR" \( -name node_modules -o -name __pycache__ -o -name .ipynb_checkpoints -o -name .git \) -type d -prune -exec rm -rf {} + 2>/dev/null || true
+            find "$SKILL_DIR" -name '*.pyc' -delete 2>/dev/null || true
+
+            # Create zip file (exclude hidden files, .gitkeep, and build artifacts)
             ZIP_FILE="$TEMP_DIR/${SKILL_NAME}.zip"
             cd "$TEMP_DIR"
-            zip -r "$ZIP_FILE" "$SKILL_NAME" -x "*/.*" "*/.gitkeep" "*.DS_Store"
+            zip -r "$ZIP_FILE" "$SKILL_NAME" \
+              -x "*/.*" "*/.gitkeep" "*.DS_Store" \
+                 "*/node_modules/*" "*/__pycache__/*" "*.pyc" "*/.ipynb_checkpoints/*"
             cd -
 
             # Verify zip was created
@@ -129,7 +137,19 @@ jobs:
               continue
             fi
 
-            echo "✓ Created zip: $(ls -lh "$ZIP_FILE" | awk '{print $5}')"
+            # Guard against the marketplace's 200-file-per-zip limit: fail loudly
+            # here (with the offending skill name) instead of getting a vague
+            # server-side rejection (see issue #57).
+            FILE_COUNT=$(unzip -l "$ZIP_FILE" | tail -1 | awk '{print $2}')
+            echo "  Files in zip: $FILE_COUNT"
+            if [ "${FILE_COUNT:-0}" -gt 190 ]; then
+              echo "❌ ERROR: $SKILL_NAME zip contains $FILE_COUNT files (limit 200)."
+              echo "   A skill folder should not ship build artifacts or hundreds of files."
+              echo "   Prune the folder (references/ should be a handful of docs) and retry."
+              continue
+            fi
+
+            echo "✓ Created zip: $(ls -lh "$ZIP_FILE" | awk '{print $5}') ($FILE_COUNT files)"
 
             # Write SKILL.md content to temp file (avoid argument length limits)
             SKILL_MD_FILE="$TEMP_DIR/skill.md"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,18 +4,18 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-**AI Research Skills Library** - A comprehensive open-source library of 90 AI research skills enabling AI agents to autonomously conduct AI research — from idea to paper. Each skill provides expert-level guidance (200-500 lines) with real code examples, troubleshooting guides, and production-ready workflows.
+**AI Research Skills Library** - A comprehensive open-source library of 98 AI research skills enabling AI agents to autonomously conduct AI research — from idea to paper. Each skill provides expert-level guidance (200-500 lines) with real code examples, troubleshooting guides, and production-ready workflows.
 
 **Mission**: Enable AI agents to autonomously conduct AI research from hypothesis to experimental verification, covering the full lifecycle: literature survey, ideation, dataset preparation, training pipelines, model deployment, evaluation, and paper writing.
 
 ## Repository Architecture
 
-### Directory Structure (90 Skills Across 23 Categories)
+### Directory Structure (98 Skills Across 23 Categories)
 
 Skills are organized into numbered categories representing the AI research lifecycle:
 
 - `0-autoresearch-skill/` - **Autonomous research orchestration** (1 skill: Autoresearch — central layer that manages the full lifecycle and routes to all other skills)
-- `01-model-architecture/` - Model architectures (5 skills: Megatron-Core, LitGPT, Mamba, RWKV, NanoGPT)
+- `01-model-architecture/` - Model architectures (5 skills: TorchTitan, LitGPT, Mamba, RWKV, NanoGPT)
 - `02-tokenization/` - Tokenizers (2 skills: HuggingFace Tokenizers, SentencePiece)
 - `03-fine-tuning/` - Fine-tuning frameworks (4 skills: Axolotl, LLaMA-Factory, Unsloth, PEFT)
 - `04-mechanistic-interpretability/` - Interpretability tools (4 skills: TransformerLens, SAELens, NNsight, Pyvene)
@@ -24,17 +24,17 @@ Skills are organized into numbered categories representing the AI research lifec
 - `07-safety-alignment/` - Safety and guardrails (4 skills: Constitutional AI, LlamaGuard, NeMo Guardrails, Prompt Guard)
 - `08-distributed-training/` - Distributed systems (6 skills: Megatron-Core, DeepSpeed, FSDP, Accelerate, PyTorch Lightning, Ray Train)
 - `09-infrastructure/` - Cloud compute (3 skills: Modal, SkyPilot, Lambda Labs)
-- `10-optimization/` - Optimization techniques (6 skills: Flash Attention, bitsandbytes, GPTQ, AWQ, HQQ, GGUF)
+- `10-optimization/` - Optimization techniques (7 skills: Flash Attention, bitsandbytes, GPTQ, AWQ, HQQ, GGUF, ML Training Recipes)
 - `11-evaluation/` - Benchmarking (3 skills: lm-evaluation-harness, BigCode, NeMo Evaluator)
 - `12-inference-serving/` - Inference engines (4 skills: vLLM, TensorRT-LLM, llama.cpp, SGLang)
-- `13-mlops/` - Experiment tracking (3 skills: Weights & Biases, MLflow, TensorBoard)
-- `14-agents/` - Agent frameworks (4 skills: LangChain, LlamaIndex, CrewAI, AutoGPT)
+- `13-mlops/` - Experiment tracking (4 skills: Weights & Biases, MLflow, TensorBoard, SwanLab)
+- `14-agents/` - Agent frameworks (5 skills: LangChain, LlamaIndex, CrewAI, AutoGPT, A-Evolve)
 - `15-rag/` - Retrieval-augmented generation (5 skills: Chroma, FAISS, Sentence Transformers, Pinecone, Qdrant)
 - `16-prompt-engineering/` - Structured output (4 skills: DSPy, Instructor, Guidance, Outlines)
 - `17-observability/` - LLM observability (2 skills: LangSmith, Phoenix)
-- `18-multimodal/` - Vision and speech (7 skills: CLIP, Whisper, LLaVA, Stable Diffusion, SAM, BLIP-2, AudioCraft)
+- `18-multimodal/` - Vision and speech (10 skills: CLIP, Whisper, LLaVA, Stable Diffusion, SAM, BLIP-2, AudioCraft, Cosmos Policy, OpenPI, OpenVLA-OFT)
 - `19-emerging-techniques/` - Advanced methods (6 skills: MoE Training, Model Merging, Long Context, Speculative Decoding, Knowledge Distillation, Model Pruning)
-- `20-ml-paper-writing/` - Paper writing (1 skill: ML Paper Writing with LaTeX templates for NeurIPS, ICML, ICLR, ACL, AAAI, COLM)
+- `20-ml-paper-writing/` - Paper writing (4 skills: ML Paper Writing with LaTeX templates for NeurIPS, ICML, ICLR, ACL, AAAI, COLM; Systems Paper Writing for OSDI, NSDI, ASPLOS, SOSP; Academic Plotting; Presenting Conference Talks)
 - `21-research-ideation/` - Ideation (2 skills: Research Brainstorming, Creative Thinking)
 - `22-agent-native-research-artifact/` - Agent-Native Research Artifact tooling (3 skills: ARA Compiler, ARA Research Manager, ARA Rigor Reviewer — ingestion, post-task provenance recording, and Seal Level 2 epistemic review)
 
@@ -154,10 +154,10 @@ python -c "import yaml; yaml.safe_load(open('skill-name/SKILL.md').read().split(
 
 ## Key Files
 
-- **README.md** - Project overview, all 90 skills listed with descriptions and stats
+- **README.md** - Project overview, all 98 skills listed with descriptions and stats
 - **CONTRIBUTING.md** - Complete contribution guidelines and quality standards
 - **SKILL_TEMPLATE.md** - Copy-paste scaffold for new skills
-- **ROADMAP.md** - Development roadmap (90 skills achieved)
+- **ROADMAP.md** - Development roadmap (98 skills achieved)
 - **anthropic_official_docs/** - Anthropic's official best practices for skills
 
 ## Git Workflow

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,9 +8,9 @@ Thank you for your interest in contributing! This guide will help you add new sk
 
 **Vision**: The most comprehensive open-source library of AI research skills for Claude Code.
 
-**Target**: 86 comprehensive skills covering the entire AI research lifecycle — from ideation to paper writing. ✅ Achieved.
+**Target**: A comprehensive library covering the entire AI research lifecycle — from ideation to paper writing.
 
-**Current Progress**: 86/86 skills across 22 categories (100%)
+**Current Progress**: 98 skills across 23 categories
 
 **Philosophy**: Quality > Quantity. We deleted 9 low-quality skills to maintain high standards.
 
@@ -260,25 +260,29 @@ Place skills in the correct category:
 
 ```
 claude-ai-research-skills/
-├── 01-model-architecture/      # Model architectures (GPT, LLaMA, etc.)
+├── 0-autoresearch-skill/       # Autonomous research orchestration
+├── 01-model-architecture/      # Model architectures (TorchTitan, LitGPT, Mamba, RWKV, NanoGPT)
 ├── 02-tokenization/            # Tokenizers (HuggingFace, SentencePiece)
-├── 03-fine-tuning/             # Fine-tuning frameworks (Axolotl, TRL)
-├── 04-peft/                    # Parameter-efficient methods (LoRA, QLoRA)
+├── 03-fine-tuning/             # Fine-tuning frameworks (Axolotl, LLaMA-Factory, Unsloth, PEFT)
+├── 04-mechanistic-interpretability/  # Interpretability (TransformerLens, SAELens, NNsight, Pyvene)
 ├── 05-data-processing/         # Data curation and processing
-├── 06-post-training/           # RLHF, DPO, PPO
+├── 06-post-training/           # RLHF, DPO, GRPO, PPO
 ├── 07-safety-alignment/        # Guardrails, safety, content moderation
-├── 08-distributed-training/    # DeepSpeed, FSDP, distributed systems
-├── 09-infrastructure/          # PyTorch Lightning, Ray, Composer
-├── 10-optimization/            # Flash Attention, bitsandbytes, kernels
+├── 08-distributed-training/    # Megatron-Core, DeepSpeed, FSDP, distributed systems
+├── 09-infrastructure/          # Modal, SkyPilot, Lambda Labs
+├── 10-optimization/            # Flash Attention, bitsandbytes, quantization
 ├── 11-evaluation/              # Benchmarks, evaluation frameworks
-├── 12-inference-serving/       # vLLM, TensorRT-LLM, llama.cpp
-├── 13-mlops/                   # Weights & Biases, MLflow, TensorBoard
-├── 14-agents/                  # LangChain, LlamaIndex, CrewAI
+├── 12-inference-serving/       # vLLM, TensorRT-LLM, llama.cpp, SGLang
+├── 13-mlops/                   # Weights & Biases, MLflow, TensorBoard, SwanLab
+├── 14-agents/                  # LangChain, LlamaIndex, CrewAI, AutoGPT, A-Evolve
 ├── 15-rag/                     # RAG pipelines, vector databases
-├── 16-prompt-engineering/      # DSPy, Instructor, structured output
+├── 16-prompt-engineering/      # DSPy, Instructor, Guidance, Outlines
 ├── 17-observability/           # LangSmith, Phoenix, monitoring
-├── 18-multimodal/              # LLaVA, Whisper, Stable Diffusion
-└── 19-emerging-techniques/     # MoE, model merging, long context
+├── 18-multimodal/              # CLIP, Whisper, LLaVA, Stable Diffusion, SAM, robotics policies
+├── 19-emerging-techniques/     # MoE, model merging, long context
+├── 20-ml-paper-writing/        # ML & systems paper writing, plotting, talks
+├── 21-research-ideation/       # Brainstorming and creative thinking
+└── 22-agent-native-research-artifact/  # ARA compiler, research manager, rigor reviewer
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ Install skill categories directly using the **Claude Code CLI**:
 
 ## Demos
 
-All 87 skills in this repo are automatically synced to [Orchestra Research](https://www.orchestra-research.com/research-skills), where you can add them to your projects with one click and use them with AI research agents.
+All 98 skills in this repo are automatically synced to [Orchestra Research](https://www.orchestra-research.com/research-skills), where you can add them to your projects with one click and use them with AI research agents.
 
 **See skills in action → [demos/](demos/README.md)**
 
@@ -369,7 +369,7 @@ skill-name/
 
 ## Roadmap
 
-We're building towards 80 comprehensive skills across the full AI research lifecycle. See our [detailed roadmap](docs/ROADMAP.md) for the complete development plan.
+The library spans 98 comprehensive skills across the full AI research lifecycle. See our [detailed roadmap](docs/ROADMAP.md) for the complete development plan.
 
 [View Full Roadmap →](docs/ROADMAP.md)
 

--- a/WELCOME.md
+++ b/WELCOME.md
@@ -10,7 +10,7 @@ Run this once to install all skills to your agent permanently:
 npx @orchestra-research/ai-research-skills install --all
 ```
 
-This auto-detects your coding agent (Claude Code, OpenClaw, Cursor, etc.) and installs 86 skills across 22 categories.
+This auto-detects your coding agent (Claude Code, OpenClaw, Cursor, etc.) and installs 98 skills across 23 categories.
 
 **Important**: After installation completes, you may need to restart your agent session for the newly installed skills to be loaded and available. If skills aren't recognized after install, restart and come back to Step 2.
 
@@ -30,7 +30,7 @@ Autoresearch will:
 - Show you research presentations along the way
 - Write the paper when ready
 
-You don't need to know all 86 skills upfront. Autoresearch finds and invokes the right ones for you.
+You don't need to know all 98 skills upfront. Autoresearch finds and invokes the right ones for you.
 
 ## That's It
 

--- a/demos/README.md
+++ b/demos/README.md
@@ -230,5 +230,5 @@ Want to showcase a skill? We welcome demo contributions!
 ## Quick Links
 
 - [Main Skills Library](../README.md)
-- [All 87 Skills](../README.md#available-ai-research-engineering-skills)
+- [All 98 Skills](../README.md#available-ai-research-engineering-skills)
 - [Contributing Guide](../CONTRIBUTING.md)

--- a/packages/ai-research-skills/README.md
+++ b/packages/ai-research-skills/README.md
@@ -8,7 +8,7 @@ npx @orchestra-research/ai-research-skills
 
 ## Features
 
-- **86 skills** across 22 categories for AI research engineering
+- **98 skills** across 23 categories for AI research engineering
 - **Auto-detects** installed coding agents
 - **Interactive installer** with guided experience
 - **Global or local install** — install globally with symlinks, or per-project with `--local` for version-controlled, project-specific skill sets

--- a/scripts/check-inventory.sh
+++ b/scripts/check-inventory.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Verifies that the skill/category counts documented across the repo match the
+# actual contents on disk. Prevents inventory drift (see issue #54, where
+# CLAUDE.md, CONTRIBUTING.md, README.md and the npm package all disagreed).
+#
+# Source of truth = number of SKILL.md files and top-level category directories.
+# Run locally with:  bash scripts/check-inventory.sh
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+ACTUAL_SKILLS=$(find . -name SKILL.md -not -path '*/node_modules/*' | wc -l | tr -d ' ')
+ACTUAL_CATS=$(find . -maxdepth 1 -type d -name '[0-9]*-*' | wc -l | tr -d ' ')
+
+echo "Actual repository contents: ${ACTUAL_SKILLS} skills across ${ACTUAL_CATS} categories"
+echo "--------------------------------------------------------------"
+
+fail=0
+
+# check <file> <label> <regex> <expected>
+# Extracts the first number from the first line matching <regex> and compares it
+# to <expected>. Skips (with a warning) if the file or pattern is missing, so the
+# guard never blocks on unrelated wording changes.
+check() {
+  local file="$1" label="$2" regex="$3" expected="$4"
+  if [ ! -f "$file" ]; then
+    echo "  ⚠️  ${label}: ${file} not found (skipped)"
+    return
+  fi
+  local found
+  found=$(grep -oiE "$regex" "$file" | head -1 | grep -oE '[0-9]+' | head -1 || true)
+  if [ -z "$found" ]; then
+    echo "  ⚠️  ${label}: pattern not found in ${file} (skipped)"
+    return
+  fi
+  if [ "$found" != "$expected" ]; then
+    echo "  ❌ ${label}: ${file} says ${found}, expected ${expected}"
+    fail=1
+  else
+    echo "  ✅ ${label}: ${found}"
+  fi
+}
+
+echo "Skill counts:"
+check "CLAUDE.md"                              "CLAUDE.md header"   'Directory Structure \(([0-9]+) Skills' "$ACTUAL_SKILLS"
+check "packages/ai-research-skills/README.md"  "npm package README" '\*\*([0-9]+) skills\*\*'                "$ACTUAL_SKILLS"
+check "WELCOME.md"                             "WELCOME.md"         'installs ([0-9]+) skills'               "$ACTUAL_SKILLS"
+
+echo "Category counts:"
+check "CLAUDE.md"                              "CLAUDE.md header"   'Skills Across ([0-9]+) Categories'     "$ACTUAL_CATS"
+check "packages/ai-research-skills/README.md"  "npm package README" 'across ([0-9]+) categories'            "$ACTUAL_CATS"
+
+echo "--------------------------------------------------------------"
+if [ "$fail" -ne 0 ]; then
+  cat <<EOF
+❌ Inventory drift detected.
+
+Update the file(s) flagged above to match the actual counts:
+    ${ACTUAL_SKILLS} skills across ${ACTUAL_CATS} categories
+
+Recompute any time with:
+    find . -name SKILL.md -not -path '*/node_modules/*' | wc -l
+EOF
+  exit 1
+fi
+echo "✅ Documented inventory counts are in sync (${ACTUAL_SKILLS} skills / ${ACTUAL_CATS} categories)."


### PR DESCRIPTION
## Summary

The documented skill counts had drifted out of sync across the repo while the actual library grew to **98 skills across 23 categories**:

| File | Said | Now |
|------|------|-----|
| `CLAUDE.md` header | 90 / 23 | **98 / 23** |
| `CONTRIBUTING.md` | 86 / 22 | **98 / 23** |
| `README.md` sync line | 87 | **98** |
| `WELCOME.md` / npm package README | 86 / 22 | **98 / 23** |

This corrects every **current-facing** reference (historical changelog entries are intentionally left untouched) and adds tooling so it can't silently drift again.

## Changes
- **CLAUDE.md**: header 90→98; fix per-category listings — `01` Megatron-Core→**TorchTitan**; `10` +ML Training Recipes; `13` +SwanLab; `14` +A-Evolve; `18` +Cosmos Policy/OpenPI/OpenVLA-OFT; `20` +Systems Paper Writing/Academic Plotting/Presenting Conference Talks. *(per-category corrections harvested from #52 by @xiaolai — thank you)*
- **CONTRIBUTING.md**: 86/22→98/23; refresh the directory tree (`04-peft`→`04-mechanistic-interpretability`; add categories 0, 20–22).
- **README / WELCOME / demos / npm package README**: fix current-facing counts.
- **`scripts/check-inventory.sh` + `.github/workflows/check-inventory.yml`**: CI guard that fails when documented counts diverge from the `SKILL.md` count on disk.
- **`sync-skills.yml`**: prune build artifacts before zipping and fail loudly above 190 files instead of hitting the marketplace 200-file rejection (#57).

## Closes / addresses
- Resolves the inventory findings in #54
- Supersedes #52 (its accurate per-category edits are included here, rebased onto current `main` with the correct 98/23 totals + the missing category 22)
- Hardens the latent cause behind #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)