### PR TITLE
release: v1.7.0 — inventory consistency, drift guard & security hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,17 @@ We welcome contributions from the AI research community! See [CONTRIBUTING.md](C
 ## Recent Updates
 
 <details open>
+<summary><b>June 2026 - v1.7.0 🧹 Inventory Consistency, Drift Guard & Security Hardening</b></summary>
+
+- 📊 **Repo-wide inventory reconciled to 98 skills / 23 categories** — corrected stale counts that had drifted apart across files: CLAUDE.md (said 90), CONTRIBUTING.md (said 86/22), the README sync line (said 87), WELCOME.md and the npm package README (said 86/22). Also fixed wrong per-category listings (TorchTitan, SwanLab, A-Evolve, ML Training Recipes, Cosmos Policy/OpenPI/OpenVLA-OFT, the paper-writing skills)
+- 🛡️ **New CI drift guard** — `scripts/check-inventory.sh` + `check-inventory.yml` fail CI whenever the documented skill/category counts diverge from the actual `SKILL.md` count on disk, so the inventory can't silently drift again
+- 📦 **Marketplace sync hardening** — `sync-skills.yml` now prunes build artifacts (`node_modules`/`__pycache__`/`*.pyc`/`.ipynb_checkpoints`) before zipping and fails loudly above 190 files instead of hitting the marketplace's 200-file rejection
+- 🔒 **Security** — pinned CLI dependencies (`chalk`/`inquirer`/`ora`) to exact versions matching the lockfile
+- 🧹 Full open PR/issue triage pass against scope + contribution standards
+
+</details>
+
+<details>
 <summary><b>April 2026 - v1.6.0 🧬 Agent-Native Research Artifact (ARA) — 23rd Category, 98 Skills</b></summary>
 
 - 🧬 **NEW CATEGORY**: `22-agent-native-research-artifact/` (the 23rd category) — three skills that turn research outputs into a falsifiable, agent-traversable artifact:

--- a/packages/ai-research-skills/package-lock.json
+++ b/packages/ai-research-skills/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@orchestra-research/ai-research-skills",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchestra-research/ai-research-skills",
-      "version": "1.6.0",
+      "version": "1.7.0",
       "license": "MIT",
       "dependencies": {
         "chalk": "^5.3.0",

--- a/packages/ai-research-skills/package.json
+++ b/packages/ai-research-skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orchestra-research/ai-research-skills",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "description": "Install AI research engineering skills to your coding agents (Claude Code, OpenCode, Cursor, Gemini CLI, Hermes Agent, and more)",
   "main": "src/index.js",
   "bin": {


### PR DESCRIPTION
Bumps `@orchestra-research/ai-research-skills` **1.6.0 → 1.7.0** (minor) and adds the v1.7.0 changelog entry. Merging this triggers `publish-npm.yml` (OIDC trusted publishing).

> Note: this is a **quality/hardening** release. The 98-skill content milestone was already shipped in **v1.6.0** (ARA category), so the notes are framed as consistency + tooling + security rather than re-announcing 98 skills.

## What's in 1.7.0
- 📊 Repo-wide inventory reconciled to **98 skills / 23 categories** (CLAUDE.md, CONTRIBUTING.md, README, WELCOME, npm package README were all disagreeing) + fixed per-category listings
- 🛡️ CI drift guard (`scripts/check-inventory.sh` + `check-inventory.yml`)
- 📦 `sync-skills.yml` build-artifact pruning + 190-file guard (#57)
- 🔒 Pinned CLI deps (chalk/inquirer/ora) to exact versions (#53)

## Release checklist
- [x] `npm version minor` (package.json + lockfile both at 1.7.0)
- [x] Changelog entry added
- [x] `check-inventory` guard green
- [ ] Merge → OIDC publish → verify `npm view ... version` == 1.7.0
- [ ] Tag `v1.7.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)