### PR TITLE
fix(release): v1.7.1 — repair lockfile sync + pin deps to patched versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,12 +506,12 @@ We welcome contributions from the AI research community! See [CONTRIBUTING.md](C
 ## Recent Updates
 
 <details open>
-<summary><b>June 2026 - v1.7.0 🧹 Inventory Consistency, Drift Guard & Security Hardening</b></summary>
+<summary><b>June 2026 - v1.7.1 🧹 Inventory Consistency, Drift Guard & Security Hardening</b></summary>
 
 - 📊 **Repo-wide inventory reconciled to 98 skills / 23 categories** — corrected stale counts that had drifted apart across files: CLAUDE.md (said 90), CONTRIBUTING.md (said 86/22), the README sync line (said 87), WELCOME.md and the npm package README (said 86/22). Also fixed wrong per-category listings (TorchTitan, SwanLab, A-Evolve, ML Training Recipes, Cosmos Policy/OpenPI/OpenVLA-OFT, the paper-writing skills)
 - 🛡️ **New CI drift guard** — `scripts/check-inventory.sh` + `check-inventory.yml` fail CI whenever the documented skill/category counts diverge from the actual `SKILL.md` count on disk, so the inventory can't silently drift again
 - 📦 **Marketplace sync hardening** — `sync-skills.yml` now prunes build artifacts (`node_modules`/`__pycache__`/`*.pyc`/`.ipynb_checkpoints`) before zipping and fails loudly above 190 files instead of hitting the marketplace's 200-file rejection
-- 🔒 **Security** — pinned CLI dependencies (`chalk`/`inquirer`/`ora`) to exact versions matching the lockfile
+- 🔒 **Security** — pinned CLI dependencies (`chalk`/`inquirer`/`ora`) to exact, patched versions with a regenerated lockfile (`inquirer@9.3.8` clears the `tmp` path-traversal advisory; `npm audit` now reports 0 vulnerabilities)
 - 🧹 Full open PR/issue triage pass against scope + contribution standards
 
 </details>

--- a/packages/ai-research-skills/package-lock.json
+++ b/packages/ai-research-skills/package-lock.json
@@ -1,17 +1,17 @@
 {
   "name": "@orchestra-research/ai-research-skills",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@orchestra-research/ai-research-skills",
-      "version": "1.7.0",
+      "version": "1.7.1",
       "license": "MIT",
       "dependencies": {
-        "chalk": "^5.3.0",
-        "inquirer": "^9.2.12",
-        "ora": "^8.0.1"
+        "chalk": "5.6.2",
+        "inquirer": "9.3.8",
+        "ora": "8.2.0"
       },
       "bin": {
         "ai-research-skills": "bin/cli.js"
@@ -394,21 +394,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/inquirer/node_modules/onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "license": "MIT",
-      "dependencies": {
-        "mimic-fn": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/inquirer/node_modules/ora": {
       "version": "5.4.1",
       "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
@@ -444,12 +429,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/inquirer/node_modules/signal-exit": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
-      "license": "ISC"
     },
     "node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
@@ -543,15 +522,15 @@
       }
     },
     "node_modules/onetime": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
-      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
       "license": "MIT",
       "dependencies": {
-        "mimic-function": "^5.0.0"
+        "mimic-fn": "^2.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=6"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -660,6 +639,33 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/restore-cursor/node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/restore-cursor/node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/run-async": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-3.0.0.tgz",
@@ -705,16 +711,10 @@
       "license": "MIT"
     },
     "node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "license": "ISC",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
     },
     "node_modules/stdin-discarder": {
       "version": "0.2.2",

--- a/packages/ai-research-skills/package.json
+++ b/packages/ai-research-skills/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@orchestra-research/ai-research-skills",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "description": "Install AI research engineering skills to your coding agents (Claude Code, OpenCode, Cursor, Gemini CLI, Hermes Agent, and more)",
   "main": "src/index.js",
   "bin": {
@@ -42,8 +42,8 @@
     "node": ">=18.0.0"
   },
   "dependencies": {
-    "chalk": "5.3.0",
-    "inquirer": "9.2.12",
-    "ora": "8.0.1"
+    "chalk": "5.6.2",
+    "inquirer": "9.3.8",
+    "ora": "8.2.0"
   }
 }


### PR DESCRIPTION
**v1.7.0 merged but never published** — the `publish-npm.yml` `npm ci` step failed because #53 pinned `chalk`/`inquirer`/`ora` to exact versions in `package.json` **without regenerating `package-lock.json`** (`lock file's chalk@5.6.2 does not satisfy chalk@5.3.0`). No bad publish occurred; npm is still on 1.6.0.

While fixing it I found #53 also pinned **down** to older versions, and `inquirer@9.2.12` pulls in the vulnerable `external-editor → tmp` chain ([GHSA-52f5-9888-hmc6](https://github.com/advisories/GHSA-52f5-9888-hmc6), high). So instead of shipping a vulnerable downgrade, this pins to the current **patched** versions and regenerates the lockfile:

| dep | #53 pinned | now |
|-----|-----------|-----|
| chalk | 5.3.0 | **5.6.2** |
| inquirer | 9.2.12 (vuln) | **9.3.8** (patched) |
| ora | 8.0.1 | **8.2.0** |

- ✅ `npm ci` passes (verified locally)
- ✅ `npm audit` → **0 vulnerabilities**
- ✅ version bumped 1.7.0 → **1.7.1** (1.7.0 was never published); changelog relabeled
- Merging triggers OIDC publish of **1.7.1**

🤖 Generated with [Claude Code](https://claude.com/claude-code)