### PR TITLE
Add Atlas Cloud Media API multimodal skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,7 +5,7 @@
     "email": "zechen@orchestra-research.com"
   },
   "metadata": {
-    "description": "Comprehensive library of 98 AI research engineering skills enabling autonomous AI research from hypothesis to experimental verification",
+    "description": "Comprehensive library of 99 AI research engineering skills enabling autonomous AI research from hypothesis to experimental verification",
     "version": "1.2.0"
   },
   "plugins": [
@@ -217,10 +217,11 @@
     },
     {
       "name": "multimodal",
-      "description": "Vision, audio, and multimodal models including CLIP, Whisper, LLaVA, BLIP-2, Segment Anything, Stable Diffusion, AudioCraft, Cosmos Policy, OpenPI, and OpenVLA-OFT. Use when working with images, audio, multimodal tasks, or vision-language-action robot policies.",
+      "description": "Vision, audio, and multimodal models including CLIP, Whisper, LLaVA, BLIP-2, Segment Anything, Stable Diffusion, AudioCraft, Atlas Cloud Media API, Cosmos Policy, OpenPI, and OpenVLA-OFT. Use when working with images, audio, multimodal generation, hosted media APIs, or vision-language-action robot policies.",
       "source": "./",
       "strict": false,
       "skills": [
+        "./18-multimodal/atlas-cloud-media-api",
         "./18-multimodal/audiocraft",
         "./18-multimodal/blip-2",
         "./18-multimodal/clip",

--- a/18-multimodal/atlas-cloud-media-api/SKILL.md
+++ b/18-multimodal/atlas-cloud-media-api/SKILL.md
@@ -1,0 +1,300 @@
+---
+name: atlas-cloud-media-api
+description: Integrates Atlas Cloud media generation APIs for image, video, and OpenAI-compatible LLM workflows. Use when building research agents that need hosted text-to-image, image-to-video, text-to-video, or multimodal generation without managing local GPU inference.
+version: 1.0.0
+author: Orchestra Research
+license: MIT
+tags: [Atlas Cloud, Media Generation, Text-to-Image, Text-to-Video, Image-to-Video, OpenAI Compatible, Multimodal, Hosted Inference]
+dependencies: [requests>=2.31.0, openai>=1.0.0]
+---
+
+# Atlas Cloud Media API Integration
+
+Guide for adding Atlas Cloud hosted media generation to AI research agents and multimodal pipelines. It covers image generation, video generation, polling, model discovery, and OpenAI-compatible chat usage without requiring local diffusion or video GPUs.
+
+## When to use Atlas Cloud Media API
+
+**Use this skill when:**
+- A research workflow needs generated figures, concept art, synthetic scenes, thumbnails, storyboards, or visual assets.
+- An agent needs image-to-video or text-to-video generation as part of experiment communication.
+- Local GPU inference is too expensive, too slow to provision, or not reproducible across contributors.
+- You want one API surface for multiple image, video, and LLM providers.
+- You need OpenAI-compatible chat completions and async media generation in the same project.
+
+**Use alternatives instead:**
+- Use local Diffusers when you need custom weights, LoRA training, or full offline execution.
+- Use AudioCraft when the task is audio-only generation.
+- Use CLIP, BLIP-2, or LLaVA when the task is understanding existing media rather than generating new media.
+- Use a project-specific provider SDK if the workflow depends on provider-only features not exposed by Atlas Cloud.
+
+## Endpoint map
+
+Atlas Cloud exposes two API surfaces:
+
+| Surface | Base URL | Use |
+|---------|----------|-----|
+| Media API | `https://api.atlascloud.ai/api/v1` | Image generation, video generation, media upload, polling |
+| LLM API | `https://api.atlascloud.ai/v1` | OpenAI-compatible chat completions |
+
+All authenticated requests use:
+
+```text
+Authorization: Bearer $ATLASCLOUD_API_KEY
+Content-Type: application/json
+```
+
+Set the key once:
+
+```bash
+export ATLASCLOUD_API_KEY="your-api-key"
+```
+
+## Core rule: discover models before calling them
+
+Model IDs and input schemas change. Do not hard-code model IDs into reusable skills unless you have just verified the current model list and schema.
+
+Use this workflow:
+
+```text
+Model selection checklist:
+- [ ] Fetch the live model list from /models.
+- [ ] Filter to visible models for the required type: Image, Video, or Text.
+- [ ] Choose a model ID from the response.
+- [ ] Read the model schema or example payload when available.
+- [ ] Build the request body only from fields supported by that schema.
+- [ ] Submit once, then poll the prediction ID until completion.
+```
+
+Python model discovery:
+
+```python
+import requests
+
+MODELS_URL = "https://api.atlascloud.ai/api/v1/models"
+
+def list_models(model_type: str | None = None) -> list[dict]:
+    response = requests.get(MODELS_URL, timeout=30)
+    response.raise_for_status()
+    payload = response.json()
+    models = payload.get("data", payload if isinstance(payload, list) else [])
+
+    visible = [m for m in models if m.get("display_console", True)]
+    if model_type:
+        visible = [m for m in visible if str(m.get("type", "")).lower() == model_type.lower()]
+    return visible
+
+image_models = list_models("Image")
+video_models = list_models("Video")
+
+print("First image model:", image_models[0].get("model") or image_models[0].get("id"))
+print("First video model:", video_models[0].get("model") or video_models[0].get("id"))
+```
+
+## Workflow 1: Text-to-image generation
+
+Use this when a research agent needs a static visual artifact such as a diagram concept, cover image, visual prompt prototype, synthetic dataset sketch, or report illustration.
+
+```text
+Text-to-image checklist:
+- [ ] Confirm the user wants a generated visual, not analysis of an existing image.
+- [ ] Select a live Image model from /models.
+- [ ] Read the model schema for supported fields.
+- [ ] Submit exactly one generation request.
+- [ ] Poll every few seconds until completed or failed.
+- [ ] Save output URLs with prompt, model ID, and timestamp for reproducibility.
+```
+
+Minimal Python client:
+
+```python
+import os
+import time
+import requests
+
+MEDIA_BASE = "https://api.atlascloud.ai/api/v1"
+
+def atlas_headers() -> dict[str, str]:
+    key = os.environ["ATLASCLOUD_API_KEY"]
+    return {
+        "Authorization": f"Bearer {key}",
+        "Content-Type": "application/json",
+    }
+
+def submit_image_generation(model: str, prompt: str, **params) -> str:
+    payload = {"model": model, "prompt": prompt, **params}
+    response = requests.post(
+        f"{MEDIA_BASE}/model/generateImage",
+        headers=atlas_headers(),
+        json=payload,
+        timeout=60,
+    )
+    response.raise_for_status()
+    data = response.json()["data"]
+    return data["id"]
+
+def poll_prediction(prediction_id: str, timeout_seconds: int = 300) -> dict:
+    deadline = time.time() + timeout_seconds
+    while time.time() < deadline:
+        response = requests.get(
+            f"{MEDIA_BASE}/model/prediction/{prediction_id}",
+            headers=atlas_headers(),
+            timeout=30,
+        )
+        response.raise_for_status()
+        data = response.json()["data"]
+        status = str(data.get("status", "")).lower()
+
+        if status in {"completed", "succeeded"}:
+            return data
+        if status == "failed":
+            raise RuntimeError(f"Atlas Cloud generation failed: {data}")
+
+        time.sleep(3)
+
+    raise TimeoutError(f"Timed out waiting for prediction {prediction_id}")
+
+# Fill model with a live Image model ID from /models.
+prediction_id = submit_image_generation(
+    model="<verified-image-model-id>",
+    prompt="A clean research poster illustration of multimodal AI workflows",
+)
+result = poll_prediction(prediction_id)
+print(result.get("outputs"))
+```
+
+## Workflow 2: Text-to-video and image-to-video
+
+Use video generation when a paper, demo, or research artifact needs a motion example rather than a still image.
+
+```text
+Video generation checklist:
+- [ ] Decide text-to-video or image-to-video.
+- [ ] For image-to-video, upload or host the source image first.
+- [ ] Select a live Video model from /models.
+- [ ] Confirm whether the schema expects image, image_url, first_frame, or another input field.
+- [ ] Submit one generation request.
+- [ ] Poll for completion; video jobs can take minutes.
+```
+
+Generic video submission:
+
+```python
+def submit_video_generation(model: str, prompt: str, **params) -> str:
+    payload = {"model": model, "prompt": prompt, **params}
+    response = requests.post(
+        f"{MEDIA_BASE}/model/generateVideo",
+        headers=atlas_headers(),
+        json=payload,
+        timeout=60,
+    )
+    response.raise_for_status()
+    return response.json()["data"]["id"]
+
+# Fill model and params from the live schema for the selected Video model.
+prediction_id = submit_video_generation(
+    model="<verified-video-model-id>",
+    prompt="A short cinematic clip showing an AI research workflow diagram assembling itself",
+)
+video_result = poll_prediction(prediction_id, timeout_seconds=900)
+print(video_result.get("outputs"))
+```
+
+For image-to-video, do not guess the input field name. Use the schema for the selected model:
+
+```python
+prediction_id = submit_video_generation(
+    model="<verified-image-to-video-model-id>",
+    prompt="Animate the figure with subtle camera motion and readable layout",
+    image_url="https://example.com/source-frame.png",
+)
+```
+
+If the schema uses `image` instead of `image_url`, send `image=...` and omit `image_url`.
+
+## Workflow 3: OpenAI-compatible LLM calls
+
+Atlas Cloud LLM endpoints use the OpenAI SDK shape. This is useful when the same agent needs reasoning, prompt expansion, or asset planning before media generation.
+
+```python
+import os
+from openai import OpenAI
+
+client = OpenAI(
+    api_key=os.environ["ATLASCLOUD_API_KEY"],
+    base_url="https://api.atlascloud.ai/v1",
+)
+
+response = client.chat.completions.create(
+    model="<verified-llm-model-id>",
+    messages=[
+        {"role": "system", "content": "You write concise prompts for research visuals."},
+        {"role": "user", "content": "Turn this experiment summary into a visual prompt."},
+    ],
+    max_tokens=512,
+)
+
+print(response.choices[0].message.content)
+```
+
+## Reproducibility notes
+
+Store enough metadata to reproduce or audit media outputs:
+
+```json
+{
+  "provider": "atlas-cloud",
+  "model": "<verified-model-id>",
+  "prediction_id": "<prediction-id>",
+  "prompt": "<prompt>",
+  "params": {},
+  "submitted_at": "<iso-timestamp>",
+  "outputs": []
+}
+```
+
+For research artifacts, keep generated media separate from source data and treat outputs as derived artifacts unless the experiment explicitly depends on them.
+
+## Error handling
+
+| Failure | Likely cause | Fix |
+|---------|--------------|-----|
+| `401` | Missing or invalid API key | Check `ATLASCLOUD_API_KEY` |
+| `402` | Account has insufficient balance | Top up or switch to a cheaper model |
+| `429` | Rate limit | Back off and retry later |
+| `failed` prediction | Model rejected input or backend error | Record the full response and revise prompt or params |
+| Timeout | Video job still running | Increase polling timeout and keep the prediction ID |
+
+Do not automatically retry POST generation requests. A retry can create duplicate billable jobs. Retry polling GET requests with exponential backoff if needed.
+
+## Common integration patterns
+
+**Prompt expansion pipeline**
+1. Use the LLM API to turn a research concept into a precise visual prompt.
+2. Submit the prompt to a verified image model and store the prompt, model, and output URL.
+
+**Storyboard pipeline**
+1. Generate 3-6 still frames for a method explanation.
+2. Select one frame manually or with reviewer feedback.
+3. Submit the selected frame to a verified image-to-video model.
+4. Export output URLs into the demo assets folder.
+
+**Agent tool wrapper**
+1. Expose `generate_image`, `generate_video`, and `poll_prediction` as agent tools.
+2. Validate user intent and model type before submission.
+3. Require confirmation for expensive or long-running video jobs.
+4. Return prediction IDs immediately so the agent can continue other work while polling.
+
+## Safety and review checklist
+
+Before committing an Atlas Cloud integration:
+
+```text
+Review checklist:
+- [ ] No real API key is committed.
+- [ ] Model IDs used in examples are placeholders or were verified from /models.
+- [ ] Request payload fields match the selected model schema.
+- [ ] POST generation calls are not retried automatically.
+- [ ] Polling has a timeout and records failed responses.
+- [ ] Generated media outputs are logged as derived artifacts.
+- [ ] The workflow does not use upload endpoints as permanent file hosting.
+```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@
 
 <div align="center">
 
-### **98 Skills Powering AI Research in 2026**
+### **99 Skills Powering AI Research in 2026**
 
 </div>
 
@@ -74,7 +74,7 @@ AI Researchers spend more time debugging infrastructure than testing hypotheses 
 We provide a comprehensive skills library that enables AI agents to autonomously conduct the full research lifecycle — from brainstorming ideas to writing the paper.
   - Autonomous Research - The **autoresearch** skill orchestrates the entire research workflow using a two-loop architecture, routing to domain skills as needed
   - Specialized Expertise - Each domain skill provides deep, production-ready knowledge of a specific framework (Megatron-LM, vLLM, TRL, etc.)
-  - End-to-End Coverage - 98 skills spanning the full AI research lifecycle, from ideation and literature survey to experiments and paper writing
+  - End-to-End Coverage - 99 skills spanning the full AI research lifecycle, from ideation and literature survey to experiments and paper writing
   - Research-Grade Quality - Documentation sourced from official repos, real GitHub issues, and battle-tested production workflows
 
 ## Available AI Research Engineering Skills
@@ -95,7 +95,7 @@ npx @orchestra-research/ai-research-skills
 Read https://www.orchestra-research.com/ai-research-skills/welcome.md and follow the instructions to install and use AI Research Skills.
 ```
 
-This installs all 98 skills, loads the **autoresearch** orchestration layer, and starts autonomous research.
+This installs all 99 skills, loads the **autoresearch** orchestration layer, and starts autonomous research.
 
 <details>
 <summary><b>What the installer does</b></summary>
@@ -141,7 +141,7 @@ Install skill categories directly using the **Claude Code CLI**:
 
 </details>
 
-### All 23 Categories (98 Skills)
+### All 23 Categories (99 Skills)
 
 | Category | Skills | Included |
 |----------|--------|----------|
@@ -165,12 +165,12 @@ Install skill categories directly using the **Claude Code CLI**:
 | RAG | 5 | Chroma, FAISS, Pinecone, Qdrant, Sentence Transformers |
 | Prompt Eng | 4 | DSPy, Instructor, Guidance, Outlines |
 | Observability | 2 | LangSmith, Phoenix |
-| Multimodal | 7 | CLIP, Whisper, LLaVA, BLIP-2, SAM, Stable Diffusion, AudioCraft |
+| Multimodal | 8 | CLIP, Whisper, LLaVA, BLIP-2, SAM, Stable Diffusion, AudioCraft, Atlas Cloud Media API |
 | Emerging | 6 | MoE, Model Merging, Long Context, Speculative Decoding, Distillation, Pruning |
 | Agent-Native Research Artifact | 3 | ARA Compiler, Research Manager, Rigor Reviewer |
 
 <details>
-<summary><b>View All 98 Skills in Details</b></summary>
+<summary><b>View All 99 Skills in Details</b></summary>
 
 ### 🔬 Autoresearch (1 skill) — Central Orchestration Layer
 - **[Autoresearch](0-autoresearch-skill/)** - Autonomous research orchestration using a two-loop architecture (inner optimization + outer synthesis). Manages the full lifecycle from literature survey to paper writing, routing to all domain-specific skills. Supports Claude Code /loop and OpenClaw heartbeat for continuous operation (390 lines + 3 refs)
@@ -264,7 +264,7 @@ Install skill categories directly using the **Claude Code CLI**:
 - **[Pinecone](15-rag/pinecone/)** - Managed vector database, auto-scaling, <100ms latency (410 lines)
 - **[Qdrant](15-rag/qdrant/)** - High-performance vector search, Rust-powered, hybrid search with filtering (493 lines + 2 refs)
 
-### 🎨 Multimodal (7 skills)
+### 🎨 Multimodal (8 skills)
 - **[CLIP](18-multimodal/clip/)** - OpenAI's vision-language model, zero-shot classification, 25k stars (320 lines)
 - **[Whisper](18-multimodal/whisper/)** - Robust speech recognition, 99 languages, 73k stars (395 lines)
 - **[LLaVA](18-multimodal/llava/)** - Vision-language assistant, image chat, GPT-4V level (360 lines)
@@ -272,6 +272,7 @@ Install skill categories directly using the **Claude Code CLI**:
 - **[Segment Anything](18-multimodal/segment-anything/)** - Meta's SAM for zero-shot image segmentation with points/boxes (500 lines + 2 refs)
 - **[BLIP-2](18-multimodal/blip-2/)** - Vision-language pretraining with Q-Former, image captioning, VQA (500 lines + 2 refs)
 - **[AudioCraft](18-multimodal/audiocraft/)** - Meta's MusicGen/AudioGen for text-to-music and text-to-sound (470 lines + 2 refs)
+- **[Atlas Cloud Media API](18-multimodal/atlas-cloud-media-api/)** - Hosted image/video generation and OpenAI-compatible LLM workflows for multimodal research agents (300 lines)
 
 ### 🎯 Prompt Engineering (4 skills)
 - **[DSPy](16-prompt-engineering/dspy/)** - Declarative prompt programming with optimizers, Stanford NLP, 22k stars (438 lines + 3 refs)
@@ -314,7 +315,7 @@ Install skill categories directly using the **Claude Code CLI**:
 
 ## Demos
 
-All 98 skills in this repo are automatically synced to [Orchestra Research](https://www.orchestra-research.com/research-skills), where you can add them to your projects with one click and use them with AI research agents.
+All 99 skills in this repo are automatically synced to [Orchestra Research](https://www.orchestra-research.com/research-skills), where you can add them to your projects with one click and use them with AI research agents.
 
 **See skills in action → [demos/](demos/README.md)**
 
@@ -369,7 +370,7 @@ skill-name/
 
 ## Roadmap
 
-The library spans 98 comprehensive skills across the full AI research lifecycle. See our [detailed roadmap](docs/ROADMAP.md) for the complete development plan.
+The library spans 99 comprehensive skills across the full AI research lifecycle. See our [detailed roadmap](docs/ROADMAP.md) for the complete development plan.
 
 [View Full Roadmap →](docs/ROADMAP.md)
 
@@ -419,7 +420,7 @@ claude-ai-research-skills/
 ├── 15-rag/                      (5 skills ✓ - Chroma, FAISS, Sentence Transformers, Pinecone, Qdrant)
 ├── 16-prompt-engineering/       (4 skills ✓ - DSPy, Instructor, Guidance, Outlines)
 ├── 17-observability/            (2 skills ✓ - LangSmith, Phoenix)
-├── 18-multimodal/               (7 skills ✓ - CLIP, Whisper, LLaVA, Stable Diffusion, SAM, BLIP-2, AudioCraft)
+├── 18-multimodal/               (8 skills ✓ - CLIP, Whisper, LLaVA, Stable Diffusion, SAM, BLIP-2, AudioCraft, Atlas Cloud Media API)
 ├── 19-emerging-techniques/      (6 skills ✓ - MoE, Model Merging, Long Context, Speculative Decoding, Distillation, Pruning)
 ├── 20-ml-paper-writing/         (2 skills ✓ - ML Paper Writing with LaTeX templates, Academic Plotting)
 ├── 21-research-ideation/           (2 skills ✓ - Research Brainstorming, Creative Thinking)


### PR DESCRIPTION
## Summary
- Add an Atlas Cloud Media API skill under the multimodal category
- Cover hosted image/video generation, polling, model discovery, and OpenAI-compatible LLM calls
- Register the skill in the Claude plugin marketplace and update the README multimodal listing/counts

## Validation
- Parsed the new SKILL.md YAML frontmatter successfully
- Parsed `.claude-plugin/marketplace.json` successfully
- Verified the new skill is 300 lines and uses placeholders/live model discovery instead of hard-coded model IDs or secrets
- Self-reviewed the diff to confirm no sponsor block, logo wall, API credits, or partnership placement was added