### PR TITLE
Add token-count badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
   <a href="https://join.slack.com/t/orchestrarese-efu1990/shared_invite/zt-3iu6gr8io-zJvpkZTPToEviQ9KFZvNSg"><img src="https://img.shields.io/badge/Slack-Join%20Community-4A154B.svg?logo=slack" alt="Slack"></a>
   <a href="https://x.com/orch_research"><img src="https://img.shields.io/badge/Twitter-Follow-1DA1F2.svg?logo=x" alt="Twitter"></a>
   <a href="https://www.linkedin.com/company/orchestra-research/"><img src="https://img.shields.io/badge/LinkedIn-Follow-0A66C2.svg?logo=linkedin" alt="LinkedIn"></a>
+  <img src="https://img.shields.io/endpoint?url=https://gittokens.rsamf.com/badge/Orchestra-Research/AI-Research-SKILLs" alt="tokens">
 </p>
 
 <div align="center">


### PR DESCRIPTION
Hi! This PR adds one line to the README: a badge showing an estimate of how many LLM tokens this repo weighs. Since this project is the kind of thing people load into an LLM's context window, the number seemed genuinely useful to surface.

Preview: ![tokens](https://img.shields.io/endpoint?url=https://gittokens.rsamf.com/badge/Orchestra-Research/AI-Research-SKILLs)

Full disclosure: I built the free, open-source service behind the badge (https://github.com/rsamf/gittokens), and I'm proposing it to a small, hand-picked set of repos where it seems like a good fit. If it isn't a fit here, please just close this, and I won't resubmit.