### PR TITLE
Refine ML paper writing around claims and reader-first figures

### DIFF
--- a/20-ml-paper-writing/ml-paper-writing/SKILL.md
+++ b/20-ml-paper-writing/ml-paper-writing/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: ml-paper-writing
 description: Write and revise publication-ready ML/AI papers for NeurIPS, ICML, ICLR, ACL, AAAI, and COLM. Use when turning a research repository into a claim-driven paper, organizing methods and experiments, designing readable figures, verifying citations, or preparing a submission. For systems venues, use systems-paper-writing instead.
+license: MIT
+metadata:
+  version: 1.3.0
+  author: Orchestra Research
+  tags: [Academic Writing, ML Research, Paper Architecture, Figures, Citations, LaTeX, ICLR, ICML, NeurIPS]
 ---
 
 # ML Paper Writing

--- a/20-ml-paper-writing/ml-paper-writing/SKILL.md
+++ b/20-ml-paper-writing/ml-paper-writing/SKILL.md
@@ -1,982 +1,336 @@
 ---
 name: ml-paper-writing
-description: Write publication-ready ML/AI papers for NeurIPS, ICML, ICLR, ACL, AAAI, COLM. Use when drafting papers from research repos, structuring arguments, verifying citations, or preparing camera-ready submissions. For systems venues (OSDI, NSDI, ASPLOS, SOSP), use systems-paper-writing instead.
-version: 1.2.0
-author: Orchestra Research
-license: MIT
-tags: [Academic Writing, NeurIPS, ICML, ICLR, ACL, AAAI, COLM, LaTeX, Paper Writing, Citations, Research]
-dependencies: [semanticscholar, arxiv, habanero, requests]
+description: Write and revise publication-ready ML/AI papers for NeurIPS, ICML, ICLR, ACL, AAAI, and COLM. Use when turning a research repository into a claim-driven paper, organizing methods and experiments, designing readable figures, verifying citations, or preparing a submission. For systems venues, use systems-paper-writing instead.
 ---
 
-# ML Paper Writing for Top AI Conferences
+# ML Paper Writing
 
-Expert-level guidance for writing publication-ready papers targeting **NeurIPS, ICML, ICLR, ACL, AAAI, COLM**. This skill combines writing philosophy from top researchers (Nanda, Farquhar, Karpathy, Lipton, Steinhardt) with practical tools: LaTeX templates, citation verification APIs, and conference checklists.
+Write the paper around one scientific argument, not around the order in which
+the code or experiments were built. Preserve uncertainty and evidence
+boundaries while still producing concrete drafts.
 
-**For systems venues (OSDI, NSDI, ASPLOS, SOSP)**, use the [systems-paper-writing](../systems-paper-writing/) skill, which provides paragraph-level structural blueprints, writing patterns, venue-specific checklists, and LaTeX templates for systems conferences.
+## Non-negotiable rules
 
-## Core Philosophy: Collaborative Writing
+1. **Never invent citations.** Search for the paper, verify the metadata and
+   attributed claim, and fetch BibTeX from an authoritative source. If a source
+   cannot be verified, insert an explicit `[CITATION NEEDED]` placeholder and
+   tell the researcher.
+2. **Do not turn plans or diagnostics into results.** Distinguish planned
+   protocols, configuration checks, smoke tests, development evidence, and
+   claim-facing held-out results.
+3. **Freeze the scientific object before writing around it.** Record the active
+   method, dataset split, baselines, metrics, approximations, and unresolved
+   decisions. Treat nearby legacy artifacts as historical unless provenance
+   explicitly promotes them.
+4. **Keep claims paired with evidence.** Every headline claim needs a figure,
+   table, theorem, or analysis that can support or falsify it.
+5. **Render what readers will see.** Compile after substantive LaTeX changes
+   and inspect the actual pages, figures, captions, tables, and references.
 
-**Paper writing is collaborative, but Claude should be proactive in delivering drafts.**
+## Load the required detailed guidance
 
-The typical workflow starts with a research repository containing code, results, and experimental artifacts. Claude's role is to:
+The entrypoint is intentionally concise. Before acting, read the complete
+reference that matches the task:
 
-1. **Understand the project** by exploring the repo, results, and existing documentation
-2. **Deliver a complete first draft** when confident about the contribution
-3. **Search literature** using web search and APIs to find relevant citations
-4. **Refine through feedback cycles** when the scientist provides input
-5. **Ask for clarification** only when genuinely uncertain about key decisions
+- **Paper story, section organization, or Figure 1:** read
+  [paper-architecture.md](references/paper-architecture.md).
+- **Adding or auditing citations:** read
+  [citation-workflow.md](references/citation-workflow.md) before writing any
+  BibTeX.
+- **Starting, converting, or submitting a venue-formatted paper:** read the
+  current venue section in [checklists.md](references/checklists.md) and the
+  relevant instructions in [templates/README.md](templates/README.md).
+- **Sentence-level revision:** read the relevant section of
+  [writing-guide.md](references/writing-guide.md).
+- **Simulating review or preparing rebuttal:** read
+  [reviewer-guidelines.md](references/reviewer-guidelines.md).
 
-**Key Principle**: Be proactive. If the repo and results are clear, deliver a full draft. Don't block waiting for feedback on every section—scientists are busy. Produce something concrete they can react to, then iterate based on their response.
+Do not treat a link as optional when its trigger applies.
 
----
+## Start with the paper contract
 
-## ⚠️ CRITICAL: Never Hallucinate Citations
+Before polishing prose, write a short contract:
 
-**This is the most important rule in academic writing with AI assistance.**
-
-### The Problem
-AI-generated citations have a **~40% error rate**. Hallucinated references—papers that don't exist, wrong authors, incorrect years, fabricated DOIs—are a serious form of academic misconduct that can result in desk rejection or retraction.
-
-### The Rule
-**NEVER generate BibTeX entries from memory. ALWAYS fetch programmatically.**
-
-| Action | ✅ Correct | ❌ Wrong |
-|--------|-----------|----------|
-| Adding a citation | Search API → verify → fetch BibTeX | Write BibTeX from memory |
-| Uncertain about a paper | Mark as `[CITATION NEEDED]` | Guess the reference |
-| Can't find exact paper | Note: "placeholder - verify" | Invent similar-sounding paper |
-
-### When You Can't Verify a Citation
-
-If you cannot programmatically verify a citation, you MUST:
-
-```latex
-% EXPLICIT PLACEHOLDER - requires human verification
-\cite{PLACEHOLDER_author2024_verify_this}  % TODO: Verify this citation exists
+```text
+Research question:
+Answer the paper aims to establish:
+One-sentence contribution:
+Why the community should care:
+Evidence required for each claim:
+Current evidence boundary:
+Known approximations and limitations:
+Target venue and page budget:
 ```
 
-**Always tell the scientist**: "I've marked [X] citations as placeholders that need verification. I could not confirm these papers exist."
+Obtain explicit researcher confirmation of the one-sentence contribution when
+multiple scientific framings remain plausible. If the framing has already been
+agreed and recorded, draft proactively and flag lesser uncertainty inside the
+draft or handoff rather than reopening settled choices.
+
+For a repository-backed paper, make a read-only first pass before relying on
+filenames or historical summaries:
+
+1. list tracked files and top-level directories;
+2. read the active README, method contract, and experiment configuration;
+3. locate result manifests, terminal receipts, plots, and draft documents;
+4. locate existing `.bib` files and citation anchors;
+5. record which artifacts are current, historical, incomplete, or invalidated.
+
+Prefer versioned artifacts over terminal history. Do not execute experiments or
+rewrite assets merely to understand the repository.
+
+## Build a claim--evidence ledger
+
+Create this table before deciding the paper structure:
+
+| Claim | Why it matters | Required evidence | Current status | Paper home |
+|---|---|---|---|---|
+| Main result | Community-level consequence | Matched held-out comparison | complete / pending | Fig. 1 or main table |
+| Mechanism | Why the method works | Controlled ablation | complete / pending | main experiments |
+| Efficiency | Practical cost | Amortized wall time and memory | complete / pending | main or appendix |
+| Scope | Where the guarantee applies | theorem and approximation audit | complete / pending | method + appendix |
+
+Use the ledger to remove unsupported adjectives and to prevent a long benchmark
+inventory from replacing an argument. See
+[references/paper-architecture.md](references/paper-architecture.md) for a
+detailed template and reviewer-question map.
+
+## Organize the paper around reader questions
+
+A strong default structure is:
+
+1. **Introduction:** What is the problem, why do existing approaches miss it,
+   what is the idea, and what evidence will support the answer?
+2. **Method:** What distribution or algorithm is being proposed, why is it
+   tractable, and what is exact versus approximate?
+3. **Experiments:** Does it work, why does it work, when does it fail, and what
+   does it cost?
+4. **Related work:** Which assumptions and capabilities distinguish the method?
+5. **Limitations and conclusion:** What was established, and what remains out
+   of scope?
+
+Do not reproduce the engineering chronology. Group experiments by research
+question or claim, not by dataset. Put each figure near the paragraph that
+states what the reader should learn from it.
+
+## Design Figure 1 before polishing the abstract
+
+Many readers inspect the title, abstract, Figure 1, and introduction before the
+method. Make Figure 1 pass this ten-second test:
+
+- What problem enters on the left?
+- What is the one new idea in the middle?
+- What useful behavior or output appears on the right?
+- Which part is the authors' contribution?
 
-### Recommended: Install Exa MCP for Paper Search
+Use a low-symbol visual grammar:
 
-For the best paper search experience, install **Exa MCP** which provides real-time academic search:
+- Prefer 3--5 conceptual steps over a miniature derivation.
+- Use plain-language labels before acronyms or state variables.
+- Introduce at most one indispensable equation in an overview figure.
+- Do not place notation in a box unless the notation is discussed in the
+  caption or adjacent paragraph.
+- Encode roles with a small, consistent color palette; also use shape, border,
+  or labels so the figure survives grayscale and color-vision differences.
+- Keep implementation details, tensor layouts, and full state diagrams in a
+  later technical figure or the appendix.
+- Write a self-contained caption that states the takeaway, not just the list of
+  components.
 
-**Claude Code:**
-```bash
-claude mcp add exa -- npx -y mcp-remote "https://mcp.exa.ai/mcp"
-```
+For a complex method, use two levels: a low-symbol overview in Figure 1 and a
+formal mechanism figure beside the relevant equations.
 
-**Cursor / VS Code** (add to MCP settings):
-```json
-{
-  "mcpServers": {
-    "exa": {
-      "type": "http",
-      "url": "https://mcp.exa.ai/mcp"
-    }
-  }
-}
-```
+## Write the method in layers
 
-Exa MCP enables searches like:
-- "Find papers on RLHF for language models published after 2023"
-- "Search for transformer architecture papers by Vaswani"
-- "Get recent work on sparse autoencoders for interpretability"
+Present the method in this order:
 
-Then verify results with Semantic Scholar API and fetch BibTeX via DOI.
+1. **Verbal contract:** one paragraph describing input, transformation, and
+   output without notation.
+2. **Core mathematical object:** one boxed distribution, objective, or update
+   that defines the method.
+3. **Mechanism:** the minimum equations needed to explain why the computation
+   realizes that object.
+4. **Guarantee and boundary:** state exactly what is proved, on what support,
+   and under which assumptions.
+5. **Implementation:** explain batching, caching, approximations, and complexity
+   after the reader understands the algorithm.
 
----
+Use one symbol for one concept and keep it stable. Define notation immediately
+before use. Move repeated factor expansions, full derivations, proofs, edge
+cases, and pseudocode to the appendix when the main text can point to a single
+clear abstraction.
 
-## Workflow 0: Starting from a Research Repository
+If the deployed system is approximate, separate four objects explicitly:
 
-When beginning paper writing, start by understanding the project:
+- the ideal target or scientific goal;
+- the tractable model actually defined by the method;
+- the retained support or engineering approximation;
+- the empirical evaluator used to judge outputs.
 
-```
-Project Understanding:
-- [ ] Step 1: Explore the repository structure
-- [ ] Step 2: Read README, existing docs, and key results
-- [ ] Step 3: Identify the main contribution with the scientist
-- [ ] Step 4: Find papers already cited in the codebase
-- [ ] Step 5: Search for additional relevant literature
-- [ ] Step 6: Outline the paper structure together
-- [ ] Step 7: Draft sections iteratively with feedback
-```
+Never use a theorem about the tractable model to imply that an external reward
+or evaluator is exact.
 
-**Step 1: Explore the Repository**
+## Write experiments as answers
 
-```bash
-# Understand project structure
-ls -la
-find . -name "*.py" | head -20
-find . -name "*.md" -o -name "*.txt" | xargs grep -l -i "result\|conclusion\|finding"
-```
+For every experiment, include three sentences or their clear equivalents:
 
-Look for:
-- `README.md` - Project overview and claims
-- `results/`, `outputs/`, `experiments/` - Key findings
-- `configs/` - Experimental settings
-- Existing `.bib` files or citation references
-- Any draft documents or notes
+1. **Question:** what claim or alternative explanation does this test?
+2. **Observation:** what happened, with uncertainty and matched controls?
+3. **Support:** what does the observation support, and what does it not support?
 
-**Step 2: Identify Existing Citations**
+Include:
 
-Check for papers already referenced in the codebase:
+- data, split, model, prompt, budget, seed, and tuning protocol;
+- strongest eligible matched baselines;
+- independent task metrics rather than only the training scorer;
+- quality--control or accuracy--cost tradeoffs where optimizing one metric can
+  degrade another;
+- uncertainty, failures, and the selection rule for a final operating point;
+- wall-clock and resource accounting when efficiency is claimed.
 
-```bash
-# Find existing citations
-grep -r "arxiv\|doi\|cite" --include="*.md" --include="*.bib" --include="*.py"
-find . -name "*.bib"
-```
+Use validation data for model or hyperparameter selection and open the test set
+only after freezing the decision rule. Label single-seed, stress-panel, and
+development results accordingly.
 
-These are high-signal starting points for Related Work—the scientist has already deemed them relevant.
+## Decide what belongs in the appendix
 
-**Step 3: Clarify the Contribution**
+Keep a fact in the main paper if a reviewer needs it to understand or trust the
+headline claim. Move it to the appendix if it supports reproduction or formal
+completeness without changing the first-pass argument.
 
-Before writing, explicitly confirm with the scientist:
+Usually keep in the main text:
 
-> "Based on my understanding of the repo, the main contribution appears to be [X].
-> The key results show [Y]. Is this the framing you want for the paper,
-> or should we emphasize different aspects?"
+- the core method law and one intuitive explanation;
+- the exactness or approximation boundary;
+- decisive comparisons and ablations;
+- the most important failure or limitation;
+- the principal quality--control--compute result.
 
-**Never assume the narrative—always verify with the human.**
+Usually move to the appendix:
 
-**Step 4: Search for Additional Literature**
+- full derivations and proofs;
+- complete hyperparameter grids and prompts;
+- dataset preprocessing and asset manifests;
+- extended baseline details, extra seeds, and qualitative cases;
+- implementation pseudocode and low-level optimization details.
 
-Use web search to find relevant papers:
+Do not use the appendix to hide assumptions required for the main claim.
 
-```
-Search queries to try:
-- "[main technique] + [application domain]"
-- "[baseline method] comparison"
-- "[problem name] state-of-the-art"
-- Author names from existing citations
-```
+## Draft each section
 
-Then verify and retrieve BibTeX using the citation workflow below.
+### Abstract
 
-**Step 5: Deliver a First Draft**
+Use five functions, not necessarily five literal sentences:
 
-**Be proactive—deliver a complete draft rather than asking permission for each section.**
+1. specific problem and importance;
+2. concrete approach;
+3. main technical distinction;
+4. evidence and comparison surface;
+5. strongest verified result or a clearly labeled pending evidence boundary.
 
-If the repo provides clear results and the contribution is apparent:
-1. Write the full first draft end-to-end
-2. Present the complete draft for feedback
-3. Iterate based on scientist's response
+Avoid generic field-level openings and claims not supported by frozen evidence.
 
-If genuinely uncertain about framing or major claims:
-1. Draft what you can confidently
-2. Flag specific uncertainties: "I framed X as the main contribution—let me know if you'd prefer to emphasize Y instead"
-3. Continue with the draft rather than blocking
+### Introduction
 
-**Questions to include with the draft** (not before):
-- "I emphasized X as the main contribution—adjust if needed"
-- "I highlighted results A, B, C—let me know if others are more important"
-- "Related work section includes [papers]—add any I missed"
+Reach the method by page 2--3. Define the gap, state the one-sentence answer,
+preview the mechanism, and list 2--4 contributions. Each contribution should
+name both an artifact and the evidence that validates it.
 
----
+### Related work
 
-## When to Use This Skill
+Organize by assumptions, inference mechanisms, or capabilities. Compare groups
+of methods before listing individual papers. Cite generously but attribute only
+claims verified in the cited source.
 
-Use this skill when:
-- **Starting from a research repo** to write a paper
-- **Drafting or revising** specific sections
-- **Finding and verifying citations** for related work
-- **Formatting** for conference submission
-- **Resubmitting** to a different venue (format conversion)
-- **Iterating** on drafts with scientist feedback
+### Limitations and conclusion
 
-**Always remember**: First drafts are starting points for discussion, not final outputs.
+State the support, model, data, and evaluation limits directly. The conclusion
+should answer the research question using only claim-facing evidence; leave it
+appropriately provisional while results remain incomplete.
 
----
+## Verify citations
 
-## Balancing Proactivity and Collaboration
+Read [references/citation-workflow.md](references/citation-workflow.md) in full
+before adding citations. The required operational path is:
 
-**Default: Be proactive. Deliver drafts, then iterate.**
+For each reference:
 
-| Confidence Level | Action |
-|-----------------|--------|
-| **High** (clear repo, obvious contribution) | Write full draft, deliver, iterate on feedback |
-| **Medium** (some ambiguity) | Write draft with flagged uncertainties, continue |
-| **Low** (major unknowns) | Ask 1-2 targeted questions, then draft |
+1. search an authoritative index or publisher;
+2. confirm title, authors, year, and venue in at least one primary record;
+3. inspect the source to verify the attributed claim;
+4. fetch BibTeX through DOI, arXiv, publisher, or another authoritative record;
+5. mark unresolved items explicitly.
 
-**Draft first, ask with the draft** (not before):
+Never fabricate plausible metadata. Follow
+[references/citation-workflow.md](references/citation-workflow.md) for API and
+BibTeX procedures.
 
-| Section | Draft Autonomously | Flag With Draft |
-|---------|-------------------|-----------------|
-| Abstract | Yes | "Framed contribution as X—adjust if needed" |
-| Introduction | Yes | "Emphasized problem Y—correct if wrong" |
-| Methods | Yes | "Included details A, B, C—add missing pieces" |
-| Experiments | Yes | "Highlighted results 1, 2, 3—reorder if needed" |
-| Related Work | Yes | "Cited papers X, Y, Z—add any I missed" |
+If programmatic retrieval or claim verification fails, leave an explicit
+placeholder and list it in the handoff. Do not convert an uncertain search
+result into a manual BibTeX entry.
 
-**Only block for input when:**
-- Target venue is unclear (affects page limits, framing)
-- Multiple contradictory framings seem equally valid
-- Results seem incomplete or inconsistent
-- Explicit request to review before continuing
+## Freeze venue and template before layout work
 
-**Don't block for:**
-- Word choice decisions
-- Section ordering
-- Which specific results to show (make a choice, flag it)
-- Citation completeness (draft with what you find, note gaps)
+Choose the target venue and verify its current official author guide before
+outlining to a page budget. Read [checklists.md](references/checklists.md) and
+[templates/README.md](templates/README.md), then:
 
----
+1. copy the complete official template rather than only its main file;
+2. compile the untouched template once;
+3. keep content separate from conference style files;
+4. migrate section content, figures, and bibliography rather than merging
+   preambles when changing venues;
+5. never edit a conference `.sty` file to make the paper fit.
 
-## The Narrative Principle
+Venue rules, page limits, checklists, anonymity requirements, and disclosure
+policies change. Treat bundled templates as starting points and official venue
+pages as the current authority.
 
-**The single most critical insight**: Your paper is not a collection of experiments—it's a story with one clear contribution supported by evidence.
+## Compile and inspect
 
-Every successful ML paper centers on what Neel Nanda calls "the narrative": a short, rigorous, evidence-based technical story with a takeaway readers care about.
+After every substantive revision:
 
-**Three Pillars (must be crystal clear by end of introduction):**
+1. compile with the official venue template;
+2. inspect warnings for missing references, overfull boxes, and font issues;
+3. render pages and visually inspect Figure 1, equations, tables, captions,
+   whitespace, and page breaks;
+4. check grayscale and colorblind legibility for figures;
+5. record remaining placeholders and evidence gaps.
 
-| Pillar | Description | Example |
-|--------|-------------|---------|
-| **The What** | 1-3 specific novel claims within cohesive theme | "We prove that X achieves Y under condition Z" |
-| **The Why** | Rigorous empirical evidence supporting claims | Strong baselines, experiments distinguishing hypotheses |
-| **The So What** | Why readers should care | Connection to recognized community problems |
+Compilation success is not visual acceptance. Do not edit conference style
+files to make content fit.
 
-**If you cannot state your contribution in one sentence, you don't yet have a paper.**
+## Handoff checklist
 
----
+- [ ] One-sentence contribution is explicit and stable.
+- [ ] Claim--evidence ledger is current.
+- [ ] Active method and experiment provenance are recorded.
+- [ ] Figure 1 passes the ten-second test with a low symbol count.
+- [ ] Main method distinguishes ideal target, tractable object, approximation,
+      and evaluator.
+- [ ] Every main experiment answers a named question.
+- [ ] Plans, diagnostics, validation results, and held-out evidence are labeled.
+- [ ] Citations and attributed claims are verified.
+- [ ] Official template compiles without unresolved references.
+- [ ] Rendered pages were visually inspected.
+- [ ] Remaining evidence and writing gaps are listed for the researcher.
 
-## Paper Structure Workflow
+## References and templates
 
-### Workflow 1: Writing a Complete Paper (Iterative)
+- [paper-architecture.md](references/paper-architecture.md): claim--evidence
+  design, reader-first method structure, figure symbol budget, and appendix map.
+- [writing-guide.md](references/writing-guide.md): sentence-level clarity and
+  writing examples.
+- [citation-workflow.md](references/citation-workflow.md): citation and BibTeX
+  verification.
+- [checklists.md](references/checklists.md): venue checklists and submission
+  requirements.
+- [reviewer-guidelines.md](references/reviewer-guidelines.md): reviewer criteria
+  and rebuttal guidance.
+- [sources.md](references/sources.md): sources behind this skill.
+- [templates/README.md](templates/README.md): bundled venue templates and build
+  instructions.
 
-Copy this checklist and track progress. **Each step involves drafting → feedback → revision:**
-
-```
-Paper Writing Progress:
-- [ ] Step 1: Define the one-sentence contribution (with scientist)
-- [ ] Step 2: Draft Figure 1 → get feedback → revise
-- [ ] Step 3: Draft abstract → get feedback → revise
-- [ ] Step 4: Draft introduction → get feedback → revise
-- [ ] Step 5: Draft methods → get feedback → revise
-- [ ] Step 6: Draft experiments → get feedback → revise
-- [ ] Step 7: Draft related work → get feedback → revise
-- [ ] Step 8: Draft limitations → get feedback → revise
-- [ ] Step 9: Complete paper checklist (required)
-- [ ] Step 10: Final review cycle and submission
-```
-
-**Step 1: Define the One-Sentence Contribution**
-
-**This step requires explicit confirmation from the scientist.**
-
-Before writing anything, articulate and verify:
-- What is the single thing your paper contributes?
-- What was not obvious or present before your work?
-
-> "I propose framing the contribution as: '[one sentence]'. Does this capture
-> what you see as the main takeaway? Should we adjust the emphasis?"
-
-**Step 2: Draft Figure 1**
-
-Figure 1 deserves special attention—many readers skip directly to it.
-- Convey core idea, approach, or most compelling result
-- Use vector graphics (PDF/EPS for plots)
-- Write captions that stand alone without main text
-- Ensure readability in black-and-white (8% of men have color vision deficiency)
-
-**Step 3: Write Abstract (5-Sentence Formula)**
-
-From Sebastian Farquhar (DeepMind):
-
-```
-1. What you achieved: "We introduce...", "We prove...", "We demonstrate..."
-2. Why this is hard and important
-3. How you do it (with specialist keywords for discoverability)
-4. What evidence you have
-5. Your most remarkable number/result
-```
-
-**Delete** generic openings like "Large language models have achieved remarkable success..."
-
-**Step 4: Write Introduction (1-1.5 pages max)**
-
-Must include:
-- 2-4 bullet contribution list (max 1-2 lines each in two-column format)
-- Clear problem statement
-- Brief approach overview
-- Methods should start by page 2-3 maximum
-
-**Step 5: Methods Section**
-
-Enable reimplementation:
-- Conceptual outline or pseudocode
-- All hyperparameters listed
-- Architectural details sufficient for reproduction
-- Present final design decisions; ablations go in experiments
-
-**Step 6: Experiments Section**
-
-For each experiment, explicitly state:
-- What claim it supports
-- How it connects to main contribution
-- Experimental setting (details in appendix)
-- What to observe: "the blue line shows X, which demonstrates Y"
-
-Requirements:
-- Error bars with methodology (standard deviation vs standard error)
-- Hyperparameter search ranges
-- Compute infrastructure (GPU type, total hours)
-- Seed-setting methods
-
-**Step 7: Related Work**
-
-Organize methodologically, not paper-by-paper:
-
-**Good:** "One line of work uses Floogledoodle's assumption [refs] whereas we use Doobersnoddle's assumption because..."
-
-**Bad:** "Snap et al. introduced X while Crackle et al. introduced Y."
-
-Cite generously—reviewers likely authored relevant papers.
-
-**Step 8: Limitations Section (REQUIRED)**
-
-All major conferences require this. Counter-intuitively, honesty helps:
-- Reviewers are instructed not to penalize honest limitation acknowledgment
-- Pre-empt criticisms by identifying weaknesses first
-- Explain why limitations don't undermine core claims
-
-**Step 9: Paper Checklist**
-
-NeurIPS, ICML, and ICLR all require paper checklists. See [references/checklists.md](references/checklists.md).
-
----
-
-## Writing Philosophy for Top ML Conferences
-
-**This section distills the most important writing principles from leading ML researchers.** These aren't optional style suggestions—they're what separates accepted papers from rejected ones.
-
-> "A paper is a short, rigorous, evidence-based technical story with a takeaway readers care about." — Neel Nanda
-
-### The Sources Behind This Guidance
-
-This skill synthesizes writing philosophy from researchers who have published extensively at top venues:
-
-| Source | Key Contribution | Link |
-|--------|-----------------|------|
-| **Neel Nanda** (Google DeepMind) | The Narrative Principle, What/Why/So What framework | [How to Write ML Papers](https://www.alignmentforum.org/posts/eJGptPbbFPZGLpjsp/highly-opinionated-advice-on-how-to-write-ml-papers) |
-| **Sebastian Farquhar** (DeepMind) | 5-sentence abstract formula | [How to Write ML Papers](https://sebastianfarquhar.com/on-research/2024/11/04/how_to_write_ml_papers/) |
-| **Gopen & Swan** | 7 principles of reader expectations | [Science of Scientific Writing](https://cseweb.ucsd.edu/~swanson/papers/science-of-writing.pdf) |
-| **Zachary Lipton** | Word choice, eliminating hedging | [Heuristics for Scientific Writing](https://www.approximatelycorrect.com/2018/01/29/heuristics-technical-scientific-writing-machine-learning-perspective/) |
-| **Jacob Steinhardt** (UC Berkeley) | Precision, consistent terminology | [Writing Tips](https://bounded-regret.ghost.io/) |
-| **Ethan Perez** (Anthropic) | Micro-level clarity tips | [Easy Paper Writing Tips](https://ethanperez.net/easy-paper-writing-tips/) |
-| **Andrej Karpathy** | Single contribution focus | Various lectures |
-
-**For deeper dives into any of these, see:**
-- [references/writing-guide.md](references/writing-guide.md) - Full explanations with examples
-- [references/sources.md](references/sources.md) - Complete bibliography
-
-### Time Allocation (From Neel Nanda)
-
-Spend approximately **equal time** on each of:
-1. The abstract
-2. The introduction
-3. The figures
-4. Everything else combined
-
-**Why?** Most reviewers form judgments before reaching your methods. Readers encounter your paper as: **title → abstract → introduction → figures → maybe the rest.**
-
-### Writing Style Guidelines
-
-#### Sentence-Level Clarity (Gopen & Swan's 7 Principles)
-
-These principles are based on how readers actually process prose. Violating them forces readers to spend cognitive effort on structure rather than content.
-
-| Principle | Rule | Example |
-|-----------|------|---------|
-| **Subject-verb proximity** | Keep subject and verb close | ❌ "The model, which was trained on..., achieves" → ✅ "The model achieves... after training on..." |
-| **Stress position** | Place emphasis at sentence ends | ❌ "Accuracy improves by 15% when using attention" → ✅ "When using attention, accuracy improves by **15%**" |
-| **Topic position** | Put context first, new info after | ✅ "Given these constraints, we propose..." |
-| **Old before new** | Familiar info → unfamiliar info | Link backward, then introduce new |
-| **One unit, one function** | Each paragraph makes one point | Split multi-point paragraphs |
-| **Action in verb** | Use verbs, not nominalizations | ❌ "We performed an analysis" → ✅ "We analyzed" |
-| **Context before new** | Set stage before presenting | Explain before showing equation |
-
-**Full 7 principles with detailed examples:** See [references/writing-guide.md](references/writing-guide.md#the-7-principles-of-reader-expectations)
-
-#### Micro-Level Tips (Ethan Perez)
-
-These small changes accumulate into significantly clearer prose:
-
-- **Minimize pronouns**: ❌ "This shows..." → ✅ "This result shows..."
-- **Verbs early**: Position verbs near sentence start
-- **Unfold apostrophes**: ❌ "X's Y" → ✅ "The Y of X" (when awkward)
-- **Delete filler words**: "actually," "a bit," "very," "really," "basically," "quite," "essentially"
-
-**Full micro-tips with examples:** See [references/writing-guide.md](references/writing-guide.md#micro-level-writing-tips)
-
-#### Word Choice (Zachary Lipton)
-
-- **Be specific**: ❌ "performance" → ✅ "accuracy" or "latency" (say what you mean)
-- **Eliminate hedging**: Drop "may" and "can" unless genuinely uncertain
-- **Avoid incremental vocabulary**: ❌ "combine," "modify," "expand" → ✅ "develop," "propose," "introduce"
-- **Delete intensifiers**: ❌ "provides *very* tight approximation" → ✅ "provides tight approximation"
-
-#### Precision Over Brevity (Jacob Steinhardt)
-
-- **Consistent terminology**: Different terms for same concept creates confusion. Pick one and stick with it.
-- **State assumptions formally**: Before theorems, list all assumptions explicitly
-- **Intuition + rigor**: Provide intuitive explanations alongside formal proofs
-
-### What Reviewers Actually Read
-
-Understanding reviewer behavior helps prioritize your effort:
-
-| Paper Section | % Reviewers Who Read | Implication |
-|---------------|---------------------|-------------|
-| Abstract | 100% | Must be perfect |
-| Introduction | 90%+ (skimmed) | Front-load contribution |
-| Figures | Examined before methods | Figure 1 is critical |
-| Methods | Only if interested | Don't bury the lede |
-| Appendix | Rarely | Put only supplementary details |
-
-**Bottom line**: If your abstract and intro don't hook reviewers, they may never read your brilliant methods section.
-
----
-
-## Conference Requirements Quick Reference
-
-### ML/AI Conferences
-
-| Conference | Page Limit | Extra for Camera-Ready | Key Requirement |
-|------------|------------|------------------------|------------------|
-| **NeurIPS 2025** | 9 pages | +0 | Mandatory checklist, lay summary for accepted |
-| **ICML 2026** | 8 pages | +1 | Broader Impact Statement required |
-| **ICLR 2026** | 9 pages | +1 | LLM disclosure required, reciprocal reviewing |
-| **ACL 2025** | 8 pages (long) | varies | Limitations section mandatory |
-| **AAAI 2026** | 7 pages | +1 | Strict style file adherence |
-| **COLM 2025** | 9 pages | +1 | Focus on language models |
-
-**Systems Conferences (OSDI, NSDI, ASPLOS, SOSP)**: See the [systems-paper-writing](../systems-paper-writing/) skill for page limits, templates, deadlines, and submission rules.
-
-**Universal Requirements:**
-- Double-blind review (anonymize submissions)
-- References don't count toward page limit
-- Appendices unlimited but reviewers not required to read
-- LaTeX required for all venues
-
-**LaTeX Templates:** See [templates/](templates/) directory for all conference templates.
-
----
-
-## Using LaTeX Templates Properly
-
-### Workflow 4: Starting a New Paper from Template
-
-**Always copy the entire template directory first, then write within it.**
-
-```
-Template Setup Checklist:
-- [ ] Step 1: Copy entire template directory to new project
-- [ ] Step 2: Verify template compiles as-is (before any changes)
-- [ ] Step 3: Read the template's example content to understand structure
-- [ ] Step 4: Replace example content section by section
-- [ ] Step 5: Keep template comments/examples as reference until done
-- [ ] Step 6: Clean up template artifacts only at the end
-```
-
-**Step 1: Copy the Full Template**
-
-```bash
-# Create your paper directory with the complete template
-cp -r templates/neurips2025/ ~/papers/my-new-paper/
-cd ~/papers/my-new-paper/
-
-# Verify structure is complete
-ls -la
-# Should see: main.tex, neurips.sty, Makefile, etc.
-```
-
-**⚠️ IMPORTANT**: Copy the ENTIRE directory, not just `main.tex`. Templates include:
-- Style files (`.sty`) - required for compilation
-- Bibliography styles (`.bst`) - required for references
-- Example content - useful as reference
-- Makefiles - for easy compilation
-
-**Step 2: Verify Template Compiles First**
-
-Before making ANY changes, compile the template as-is:
-
-```bash
-# Using latexmk (recommended)
-latexmk -pdf main.tex
-
-# Or manual compilation
-pdflatex main.tex
-bibtex main
-pdflatex main.tex
-pdflatex main.tex
-```
-
-If the unmodified template doesn't compile, fix that first. Common issues:
-- Missing TeX packages → install via `tlmgr install <package>`
-- Wrong TeX distribution → use TeX Live (recommended)
-
-**Step 3: Keep Template Content as Reference**
-
-Don't immediately delete all example content. Instead:
-
-```latex
-% KEEP template examples commented out as you write
-% This shows you the expected format
-
-% Template example (keep for reference):
-% \begin{figure}[t]
-%   \centering
-%   \includegraphics[width=0.8\linewidth]{example-image}
-%   \caption{Template shows caption style}
-% \end{figure}
-
-% Your actual figure:
-\begin{figure}[t]
-  \centering
-  \includegraphics[width=0.8\linewidth]{your-figure.pdf}
-  \caption{Your caption following the same style.}
-\end{figure}
-```
-
-**Step 4: Replace Content Section by Section**
-
-Work through the paper systematically:
-
-```
-Replacement Order:
-1. Title and authors (anonymize for submission)
-2. Abstract
-3. Introduction
-4. Methods
-5. Experiments
-6. Related Work
-7. Conclusion
-8. References (your .bib file)
-9. Appendix
-```
-
-For each section:
-1. Read the template's example content
-2. Note any special formatting or macros used
-3. Replace with your content following the same patterns
-4. Compile frequently to catch errors early
-
-**Step 5: Use Template Macros**
-
-Templates often define useful macros. Check the preamble for:
-
-```latex
-% Common template macros to use:
-\newcommand{\method}{YourMethodName}  % Consistent method naming
-\newcommand{\eg}{e.g.,\xspace}        % Proper abbreviations
-\newcommand{\ie}{i.e.,\xspace}
-\newcommand{\etal}{\textit{et al.}\xspace}
-```
-
-**Step 6: Clean Up Only at the End**
-
-Only remove template artifacts when paper is nearly complete:
-
-```latex
-% BEFORE SUBMISSION - remove these:
-% - Commented-out template examples
-% - Unused packages
-% - Template's example figures/tables
-% - Lorem ipsum or placeholder text
-
-% KEEP these:
-% - All style files (.sty)
-% - Bibliography style (.bst)
-% - Required packages from template
-% - Any custom macros you're using
-```
-
-### Template Pitfalls to Avoid
-
-| Pitfall | Problem | Solution |
-|---------|---------|----------|
-| Copying only `main.tex` | Missing `.sty`, won't compile | Copy entire directory |
-| Modifying `.sty` files | Breaks conference formatting | Never edit style files |
-| Adding random packages | Conflicts, breaks template | Only add if necessary |
-| Deleting template content too early | Lose formatting reference | Keep as comments until done |
-| Not compiling frequently | Errors accumulate | Compile after each section |
-
-### Quick Template Reference
-
-#### ML/AI Conferences
-
-| Conference | Main File | Key Style File | Notes |
-|------------|-----------|----------------|-------|
-| NeurIPS 2025 | `main.tex` | `neurips.sty` | Has Makefile |
-| ICML 2026 | `example_paper.tex` | `icml2026.sty` | Includes algorithm packages |
-| ICLR 2026 | `iclr2026_conference.tex` | `iclr2026_conference.sty` | Has math_commands.tex |
-| ACL | `acl_latex.tex` | `acl.sty` | Strict formatting |
-| AAAI 2026 | `aaai2026-unified-template.tex` | `aaai2026.sty` | Very strict compliance |
-| COLM 2025 | `colm2025_conference.tex` | `colm2025_conference.sty` | Similar to ICLR |
-
-**Systems Conference Templates** (OSDI, NSDI, ASPLOS, SOSP): See the [systems-paper-writing](../systems-paper-writing/) skill.
-
----
-
-## Conference Resubmission & Format Conversion
-
-When a paper is rejected or withdrawn from one venue and resubmitted to another, format conversion is required. This is a common workflow in ML research.
-
-### Workflow 3: Converting Between Conference Formats
-
-```
-Format Conversion Checklist:
-- [ ] Step 1: Identify source and target template differences
-- [ ] Step 2: Create new project with target template
-- [ ] Step 3: Copy content sections (not preamble)
-- [ ] Step 4: Adjust page limits and content
-- [ ] Step 5: Update conference-specific requirements
-- [ ] Step 6: Verify compilation and formatting
-```
-
-**Step 1: Key Template Differences**
-
-#### ML/AI Conversions
-
-| From → To | Page Change | Key Adjustments |
-|-----------|-------------|------------------|
-| NeurIPS → ICML | 9 → 8 pages | Cut 1 page, add Broader Impact if missing |
-| ICML → ICLR | 8 → 9 pages | Can expand experiments, add LLM disclosure |
-| NeurIPS → ACL | 9 → 8 pages | Restructure for NLP conventions, add Limitations |
-| ICLR → AAAI | 9 → 7 pages | Significant cuts needed, strict style adherence |
-| Any → COLM | varies → 9 | Reframe for language model focus |
-
-**ML → Systems Conversion**: When converting to OSDI, NSDI, ASPLOS, or SOSP, see the [systems-paper-writing](../systems-paper-writing/) skill for format conversion guidance, templates, and structural differences.
-
-**Step 2: Content Migration (NOT Template Merge)**
-
-**Never copy LaTeX preambles between templates.** Instead:
-
-```bash
-# 1. Start fresh with target template
-cp -r templates/icml2026/ new_submission/
-
-# 2. Copy ONLY content sections from old paper
-# - Abstract text
-# - Section content (between \section{} commands)
-# - Figures and tables
-# - Bibliography entries
-
-# 3. Paste into target template structure
-```
-
-**Step 3: Adjusting for Page Limits**
-
-When cutting pages (e.g., NeurIPS 9 → AAAI 7):
-- Move detailed proofs to appendix
-- Condense related work (cite surveys instead of individual papers)
-- Combine similar experiments into unified tables
-- Use smaller figure sizes with subfigures
-- Tighten writing: eliminate redundancy, use active voice
-
-When expanding (e.g., ICML 8 → ICLR 9):
-- Add ablation studies reviewers requested
-- Expand limitations discussion
-- Include additional baselines
-- Add qualitative examples
-
-**Step 4: Conference-Specific Adjustments**
-
-#### ML/AI Venues
-
-| Target Venue | Required Additions |
-|--------------|-------------------|
-| **ICML** | Broader Impact Statement (after conclusion) |
-| **ICLR** | LLM usage disclosure, reciprocal reviewing agreement |
-| **ACL/EMNLP** | Limitations section (mandatory), Ethics Statement |
-| **AAAI** | Strict adherence to style file (no modifications) |
-| **NeurIPS** | Paper checklist (appendix), lay summary if accepted |
-
-**Systems Venues** (OSDI, NSDI, ASPLOS, SOSP): See the [systems-paper-writing](../systems-paper-writing/) skill for venue-specific requirements, checklists, and reviewer guidelines.
-
-**Step 5: Update References**
-
-```latex
-% Remove self-citations that reveal identity (for blind review)
-% Update any "under review" citations to published versions
-% Add new relevant work published since last submission
-```
-
-**Step 6: Addressing Previous Reviews**
-
-When resubmitting after rejection:
-- **Do** address reviewer concerns in the new version
-- **Do** add experiments/clarifications reviewers requested
-- **Don't** include a "changes from previous submission" section (blind review)
-- **Don't** reference the previous submission or reviews
-
-**Common Conversion Pitfalls:**
-- ❌ Copying `\usepackage` commands (causes conflicts)
-- ❌ Keeping old conference header/footer commands
-- ❌ Forgetting to update `\bibliography{}` path
-- ❌ Missing conference-specific required sections
-- ❌ Exceeding page limit after format change
-
----
-
-## Citation Workflow (Hallucination Prevention)
-
-**⚠️ CRITICAL**: AI-generated citations have ~40% error rate. **Never write BibTeX from memory.**
-
-### The Golden Rule
-
-```
-IF you cannot programmatically fetch a citation:
-    → Mark it as [CITATION NEEDED] or [PLACEHOLDER - VERIFY]
-    → Tell the scientist explicitly
-    → NEVER invent a plausible-sounding reference
-```
-
-### Workflow 2: Adding Citations
-
-```
-Citation Verification (MANDATORY for every citation):
-- [ ] Step 1: Search using Exa MCP or Semantic Scholar API
-- [ ] Step 2: Verify paper exists in 2+ sources (Semantic Scholar + arXiv/CrossRef)
-- [ ] Step 3: Retrieve BibTeX via DOI (programmatically, not from memory)
-- [ ] Step 4: Verify the claim you're citing actually appears in the paper
-- [ ] Step 5: Add verified BibTeX to bibliography
-- [ ] Step 6: If ANY step fails → mark as placeholder, inform scientist
-```
-
-**Step 0: Use Exa MCP for Initial Search (Recommended)**
-
-If Exa MCP is installed, use it to find relevant papers:
-```
-Search: "RLHF language model alignment 2023"
-Search: "sparse autoencoders interpretability"
-Search: "attention mechanism transformers Vaswani"
-```
-
-Then verify each result with Semantic Scholar and fetch BibTeX via DOI.
-
-**Step 1: Search Semantic Scholar**
-
-```python
-from semanticscholar import SemanticScholar
-
-sch = SemanticScholar()
-results = sch.search_paper("attention mechanism transformers", limit=5)
-for paper in results:
-    print(f"{paper.title} - {paper.paperId}")
-    print(f"  DOI: {paper.externalIds.get('DOI', 'N/A')}")
-```
-
-**Step 2: Verify Existence**
-
-Confirm paper appears in at least two sources (Semantic Scholar + CrossRef/arXiv).
-
-**Step 3: Retrieve BibTeX via DOI**
-
-```python
-import requests
-
-def doi_to_bibtex(doi: str) -> str:
-    """Get verified BibTeX from DOI via CrossRef."""
-    response = requests.get(
-        f"https://doi.org/{doi}",
-        headers={"Accept": "application/x-bibtex"}
-    )
-    response.raise_for_status()
-    return response.text
-
-# Example
-bibtex = doi_to_bibtex("10.48550/arXiv.1706.03762")
-print(bibtex)
-```
-
-**Step 4: Verify Claims**
-
-Before citing for a specific claim, access the paper and confirm the attributed claim actually appears.
-
-**Step 5: Handle Failures Explicitly**
-
-If you cannot verify a citation at ANY step:
-
-```latex
-% Option 1: Explicit placeholder
-\cite{PLACEHOLDER_smith2023_verify}  % TODO: Could not verify - scientist must confirm
-
-% Option 2: Note in text
-... as shown in prior work [CITATION NEEDED - could not verify Smith et al. 2023].
-```
-
-**Always inform the scientist:**
-> "I could not verify the following citations and have marked them as placeholders:
-> - Smith et al. 2023 on reward hacking - could not find in Semantic Scholar
-> - Jones 2022 on scaling laws - found similar paper but different authors
-> Please verify these before submission."
-
-### Summary: Citation Rules
-
-| Situation | Action |
-|-----------|--------|
-| Found paper, got DOI, fetched BibTeX | ✅ Use the citation |
-| Found paper, no DOI | ✅ Use arXiv BibTeX or manual entry from paper |
-| Paper exists but can't fetch BibTeX | ⚠️ Mark placeholder, inform scientist |
-| Uncertain if paper exists | ❌ Mark `[CITATION NEEDED]`, inform scientist |
-| "I think there's a paper about X" | ❌ **NEVER cite** - search first or mark placeholder |
-
-**🚨 NEVER generate BibTeX from memory—always fetch programmatically. 🚨**
-
-See [references/citation-workflow.md](references/citation-workflow.md) for complete API documentation.
-
----
-
-## Common Issues and Solutions
-
-**Issue: Abstract too generic**
-
-Delete first sentence if it could be prepended to any ML paper. Start with your specific contribution.
-
-**Issue: Introduction exceeds 1.5 pages**
-
-Split background into Related Work. Front-load contribution bullets. Methods should start by page 2-3.
-
-**Issue: Experiments lack explicit claims**
-
-Add sentence before each experiment: "This experiment tests whether [specific claim]..."
-
-**Issue: Reviewers find paper hard to follow**
-
-- Add explicit signposting: "In this section, we show X"
-- Use consistent terminology throughout
-- Include figure captions that stand alone
-
-**Issue: Missing statistical significance**
-
-Always include:
-- Error bars (specify: std dev or std error)
-- Number of runs
-- Statistical tests if comparing methods
-
----
-
-## Reviewer Evaluation Criteria
-
-Reviewers assess papers on four dimensions:
-
-| Criterion | What Reviewers Look For |
-|-----------|------------------------|
-| **Quality** | Technical soundness, well-supported claims |
-| **Clarity** | Clear writing, reproducible by experts |
-| **Significance** | Community impact, advances understanding |
-| **Originality** | New insights (doesn't require new method) |
-
-**Scoring (NeurIPS 6-point scale):**
-- 6: Strong Accept - Groundbreaking, flawless
-- 5: Accept - Technically solid, high impact
-- 4: Borderline Accept - Solid, limited evaluation
-- 3: Borderline Reject - Solid but weaknesses outweigh
-- 2: Reject - Technical flaws
-- 1: Strong Reject - Known results or ethics issues
-
-See [references/reviewer-guidelines.md](references/reviewer-guidelines.md) for detailed reviewer instructions.
-
----
-
-## Tables and Figures
-
-### Tables
-
-Use `booktabs` LaTeX package for professional tables:
-
-```latex
-\usepackage{booktabs}
-\begin{tabular}{lcc}
-\toprule
-Method & Accuracy ↑ & Latency ↓ \\
-\midrule
-Baseline & 85.2 & 45ms \\
-\textbf{Ours} & \textbf{92.1} & 38ms \\
-\bottomrule
-\end{tabular}
-```
-
-**Rules:**
-- Bold best value per metric
-- Include direction symbols (↑ higher is better, ↓ lower is better)
-- Right-align numerical columns
-- Consistent decimal precision
-
-### Figures
-
-- **Vector graphics** (PDF, EPS) for all plots and diagrams
-- **Raster** (PNG 600 DPI) only for photographs
-- Use **colorblind-safe palettes** (Okabe-Ito or Paul Tol)
-- Verify **grayscale readability** (8% of men have color vision deficiency)
-- **No title inside figure**—the caption serves this function
-- **Self-contained captions**—reader should understand without main text
-
----
-
-## Citing AI Research Skills
-
-If this library helped with your research — whether for training pipelines, evaluation, paper writing, or any other skill — please consider citing it in your acknowledgments or references:
-
-```bibtex
-@software{ai_research_skills,
-  title     = {AI Research Skills Library},
-  author    = {{Orchestra Research}},
-  year      = {2025},
-  url       = {https://github.com/orchestra-research/AI-research-SKILLs},
-  note      = {Open-source skills library enabling AI agents to autonomously conduct AI research}
-}
-```
-
-A brief mention in your **Acknowledgments** section is also welcome:
-
-```latex
-\section*{Acknowledgments}
-We used the AI Research Skills Library~\cite{ai_research_skills} for [experiment orchestration / evaluation / ...].
-```
-
----
-
-## References & Resources
-
-### Reference Documents (Deep Dives)
-
-| Document | Contents |
-|----------|----------|
-| [writing-guide.md](references/writing-guide.md) | Gopen & Swan 7 principles, Ethan Perez micro-tips, word choice |
-| [citation-workflow.md](references/citation-workflow.md) | Citation APIs, Python code, BibTeX management |
-| [checklists.md](references/checklists.md) | NeurIPS 16-item, ICML, ICLR, ACL requirements |
-| [reviewer-guidelines.md](references/reviewer-guidelines.md) | Evaluation criteria, scoring, rebuttals |
-| [sources.md](references/sources.md) | Complete bibliography of all sources |
-
-### LaTeX Templates
-
-Templates in `templates/` directory:
-- **ML/AI**: ICML 2026, ICLR 2026, NeurIPS 2025, ACL/EMNLP, AAAI 2026, COLM 2025
-- **Systems** (OSDI, NSDI, ASPLOS, SOSP): See [systems-paper-writing](../systems-paper-writing/) skill
-
-**Compiling to PDF:**
-- **VS Code/Cursor**: Install LaTeX Workshop extension + TeX Live → Save to auto-compile
-- **Command line**: `latexmk -pdf main.tex` or `pdflatex` + `bibtex` workflow
-- **Online**: Upload to [Overleaf](https://overleaf.com)
-
-See [templates/README.md](templates/README.md) for detailed setup instructions.
-
-### Key External Sources
-
-**Writing Philosophy:**
-- [Neel Nanda: How to Write ML Papers](https://www.alignmentforum.org/posts/eJGptPbbFPZGLpjsp/highly-opinionated-advice-on-how-to-write-ml-papers) - Narrative, "What/Why/So What"
-- [Farquhar: How to Write ML Papers](https://sebastianfarquhar.com/on-research/2024/11/04/how_to_write_ml_papers/) - 5-sentence abstract
-- [Gopen & Swan: Science of Scientific Writing](https://cseweb.ucsd.edu/~swanson/papers/science-of-writing.pdf) - 7 reader expectation principles
-- [Lipton: Heuristics for Scientific Writing](https://www.approximatelycorrect.com/2018/01/29/heuristics-technical-scientific-writing-machine-learning-perspective/) - Word choice
-- [Perez: Easy Paper Writing Tips](https://ethanperez.net/easy-paper-writing-tips/) - Micro-level clarity
-
-**APIs:** [Semantic Scholar](https://api.semanticscholar.org/api-docs/) | [CrossRef](https://www.crossref.org/documentation/retrieve-metadata/rest-api/) | [arXiv](https://info.arxiv.org/help/api/basics.html)
-
-**ML/AI Venues:** [NeurIPS](https://neurips.cc/Conferences/2025/PaperInformation/StyleFiles) | [ICML](https://icml.cc/Conferences/2025/AuthorInstructions) | [ICLR](https://iclr.cc/Conferences/2026/AuthorGuide) | [ACL](https://github.com/acl-org/acl-style-files)
-
-**Systems Venues:** See the [systems-paper-writing](../systems-paper-writing/) skill for OSDI, NSDI, ASPLOS, SOSP links and guides
-
+Conference policies and page limits change. Verify the current official author
+guide before submission. This skill originated in the open-source Orchestra
+Research AI Research Skills library.

--- a/20-ml-paper-writing/ml-paper-writing/references/paper-architecture.md
+++ b/20-ml-paper-writing/ml-paper-writing/references/paper-architecture.md
@@ -1,0 +1,177 @@
+# Claim-driven paper architecture
+
+Use this reference when a paper has accumulated many methods, experiments, or
+historical implementations and the main story is becoming difficult to follow.
+
+## 1. Freeze the active scientific object
+
+Write a one-page active capsule before drafting:
+
+| Field | Required content |
+|---|---|
+| Research question | One falsifiable question |
+| Intended answer | One sentence the paper aims to establish |
+| Active method | Mathematical object and algorithm, not a branch nickname |
+| Evidence boundary | Which results are held-out, development-only, diagnostic, or planned |
+| Baselines | Eligibility and matching rules |
+| Approximations | Search, truncation, relaxation, temperature, or estimator choices |
+| Open decisions | Items that can still change |
+
+Keep historical variants outside the default writing path. Consult them only
+to motivate an ablation or explain provenance; do not let nearby filenames
+silently redefine the current method.
+
+## 2. Turn claims into a paper skeleton
+
+For each proposed claim, fill in:
+
+```text
+Claim:
+Alternative explanation or reviewer attack:
+Decisive evidence:
+Metric and independent evaluator:
+Matched controls:
+Failure condition:
+Main-text figure or table:
+Appendix support:
+Evidence status:
+```
+
+Then order the paper by logical dependency:
+
+1. the reader understands the problem;
+2. the reader sees the proposed answer;
+3. the method defines that answer precisely;
+4. experiments test its value and mechanism;
+5. limitations state the remaining boundary.
+
+Do not order sections by implementation date or benchmark name.
+
+## 3. Separate four objects that papers often conflate
+
+### Scientific target
+
+The behavior the community actually wants, such as semantic correctness,
+safety, or physical validity.
+
+### Tractable method object
+
+The distribution, objective, controller, surrogate, or finite computation the
+method defines exactly.
+
+### Deployed approximation
+
+The retained candidates, beams, particles, finite precision, local
+temperatures, or other choices used to make the computation practical.
+
+### Evaluator
+
+The independent measurement used to judge whether generated outputs achieve
+the scientific target.
+
+A proof about the tractable object does not validate the scientific target. A
+high internal scorer value does not replace independent evaluation. A runtime
+receipt does not establish a scientific improvement.
+
+## 4. Reader-first method writing
+
+Use a two-level presentation.
+
+### Main text
+
+1. Describe input, operation, and output in plain language.
+2. Give one core mathematical law.
+3. Explain the mechanism with the fewest equations needed for causal
+   understanding.
+4. State the guarantee and approximation boundary next to the law.
+5. Explain practical computation after the algorithm is clear.
+
+### Appendix
+
+Put full factor expansions, derivations, proofs, edge cases, pseudocode,
+complexity details, and implementation contracts here. Cross-reference them at
+the exact point where a careful reader may want more detail.
+
+An equation belongs in the main paper only if removing it would prevent a
+reviewer from understanding what is new or what is guaranteed.
+
+## 5. Figure 1 design
+
+Figure 1 should communicate one idea, not prove the paper.
+
+### Ten-second questions
+
+- What goes in?
+- What is new?
+- What comes out?
+- Why is the output better or different?
+
+### Symbol budget
+
+- Use zero equations if plain-language labels suffice.
+- If an equation is essential, show one law and define its factors visually.
+- Use at most one new symbol family per panel.
+- Avoid internal variable names, tensor shapes, acronyms, and implementation
+  switches.
+- Reserve formal state diagrams and recurrence arrows for a later figure.
+
+### Visual grammar
+
+- Give each semantic role one color and keep it stable across the paper.
+- Use borders, shapes, or labels as redundant encodings.
+- Draw a left-to-right causal path with no more than five major stages.
+- Use short verb phrases: “propose tokens,” “score complete sequences,” “look
+  ahead,” “sample one path.”
+- Use whitespace to separate optional inputs from the central contribution.
+- Write a caption that states the mechanism and takeaway.
+
+### Two-figure pattern for technical methods
+
+- **Figure 1:** problem, idea, and outcome in plain language.
+- **Mechanism figure:** formal states, messages, sampling path, and exactness
+  boundary beside the method equations.
+
+## 6. Main figure and table map
+
+Assign each visual a reviewer question:
+
+| Visual | Reviewer question |
+|---|---|
+| Figure 1 | What is the idea and why should I care? |
+| Main result | Does it improve the intended tradeoff? |
+| Mechanism ablation | Is the claimed component causally responsible? |
+| Representation analysis | Does the learned surrogate represent the target? |
+| Efficiency figure | What does the capability cost after amortization? |
+| Qualitative study | When and how does behavior change? |
+
+If two visuals answer the same question, combine them or move one to the
+appendix. If a claim has no visual or theorem, either add evidence or weaken the
+claim.
+
+## 7. Working with incomplete results
+
+Write planned work as protocol, not as observed fact:
+
+- “We will compare…” is a protocol.
+- “The experiment tests whether…” is a purpose.
+- “A development diagnostic suggests…” is bounded evidence.
+- “The method improves…” requires the declared held-out comparison.
+
+Keep the conclusion provisional until claim-facing results are frozen. It is
+acceptable to leave calibrated evidence slots; it is not acceptable to fill
+them with nearby historical numbers of uncertain provenance.
+
+## 8. Final architecture audit
+
+Read only the title, abstract, section headings, Figure 1, main captions, and
+conclusion. Verify that they tell the same story. Then inspect every claim and
+ask:
+
+1. Is the subject the active method rather than a legacy variant?
+2. Does the cited evidence have the right split, controls, and evaluator?
+3. Is exactness scoped to the object actually computed?
+4. Is a quality cost or failure mode hidden by an aggregate metric?
+5. Does the appendix preserve enough detail to reproduce the claim?
+
+Only after this architecture is stable should sentence-level polishing become
+the main activity.

--- a/20-ml-paper-writing/ml-paper-writing/references/paper-architecture.md
+++ b/20-ml-paper-writing/ml-paper-writing/references/paper-architecture.md
@@ -17,6 +17,12 @@ Write a one-page active capsule before drafting:
 | Approximations | Search, truncation, relaxation, temperature, or estimator choices |
 | Open decisions | Items that can still change |
 
+This capsule is an author-internal reasoning aid.  Do not copy local paths,
+worktree names, branch names, temporary run identifiers, or version-control
+hashes into the manuscript.  A paper should state the scientific method and
+reproducibility fields; public release identifiers belong in the artifact
+documentation when they become stable.
+
 Keep historical variants outside the default writing path. Consult them only
 to motivate an ablation or explain provenance; do not let nearby filenames
 silently redefine the current method.


### PR DESCRIPTION
## Summary
- compress the top-level writing skill from a monolithic 982-line guide into a progressive-disclosure entrypoint
- add a claim-evidence workflow, explicit exact-vs-approximate boundaries, and author-internal active-method isolation
- add low-symbol Figure 1 guidance and a reader-first method/appendix split
- retain mandatory citation verification and venue-template safeguards through task-triggered reference loading
- add a dedicated paper-architecture reference with reviewer-question and figure maps

## Validation
- current skill validator passes
- read-only forward test passed on a legacy-heavy ICLR-paper scenario with incomplete evidence and dense mathematics
- bundled citation, checklist, template, reviewer, and writing references remain intact

## Scope
This changes writing guidance only; it does not add executable dependencies or modify bundled conference templates.