### PR TITLE
fix: preserve unrelated skill symlinks on uninstall

### DIFF
--- a/packages/ai-research-skills/src/installer.js
+++ b/packages/ai-research-skills/src/installer.js
@@ -1,6 +1,6 @@
-import { existsSync, mkdirSync, symlinkSync, readdirSync, readFileSync, writeFileSync, rmSync, lstatSync, cpSync } from 'fs';
+import { existsSync, mkdirSync, symlinkSync, readdirSync, readFileSync, writeFileSync, rmSync, lstatSync, realpathSync, cpSync } from 'fs';
 import { homedir } from 'os';
-import { join, basename, dirname } from 'path';
+import { join, basename, dirname, isAbsolute, relative, sep } from 'path';
 import { execSync } from 'child_process';
 import chalk from 'chalk';
 import ora from 'ora';
@@ -506,7 +506,15 @@ export async function uninstallAllSkills(agents) {
           // Only remove if it's a symlink pointing to our canonical dir
           try {
             const stats = lstatSync(linkPath);
-            if (stats.isSymbolicLink()) {
+            if (!stats.isSymbolicLink()) continue;
+
+            const relativeTarget = relative(CANONICAL_DIR, realpathSync(linkPath));
+            const isCanonicalTarget = (
+              relativeTarget === '' ||
+              (!relativeTarget.startsWith(`..${sep}`) && relativeTarget !== '..' && !isAbsolute(relativeTarget))
+            );
+
+            if (isCanonicalTarget) {
               rmSync(linkPath, { force: true });
             }
           } catch {

--- a/packages/ai-research-skills/test/installer.test.js
+++ b/packages/ai-research-skills/test/installer.test.js
@@ -1,0 +1,68 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { spawnSync } from 'node:child_process';
+import test from 'node:test';
+
+test('uninstallAllSkills removes only links that resolve inside the canonical directory', () => {
+  const home = mkdtempSync(join(tmpdir(), 'ai-research-skills-'));
+  const script = `
+    import assert from 'node:assert/strict';
+    import { existsSync, lstatSync, mkdirSync, rmSync, symlinkSync } from 'node:fs';
+    import { join } from 'node:path';
+    import { homedir } from 'node:os';
+    import { uninstallAllSkills } from './src/installer.js';
+
+    const linkExists = (path) => {
+      try {
+        lstatSync(path);
+        return true;
+      } catch {
+        return false;
+      }
+    };
+
+    const home = homedir();
+    const skillsPath = join(home, '.agents', 'skills');
+    const canonicalTarget = join(home, '.orchestra', 'skills', '01-testing', 'owned');
+    const unrelatedTarget = join(home, 'shared-skills', 'unrelated');
+    const prefixCollisionTarget = join(home, '.orchestra', 'skills-other', 'collision');
+    const brokenTarget = join(home, 'shared-skills', 'broken');
+    mkdirSync(canonicalTarget, { recursive: true });
+    mkdirSync(unrelatedTarget, { recursive: true });
+    mkdirSync(prefixCollisionTarget, { recursive: true });
+    mkdirSync(brokenTarget, { recursive: true });
+    mkdirSync(skillsPath, { recursive: true });
+
+    const ownedLink = join(skillsPath, 'owned');
+    const unrelatedLink = join(skillsPath, 'unrelated');
+    const prefixCollisionLink = join(skillsPath, 'prefix-collision');
+    const brokenLink = join(skillsPath, 'broken');
+    symlinkSync(canonicalTarget, ownedLink, 'junction');
+    symlinkSync(unrelatedTarget, unrelatedLink, 'junction');
+    symlinkSync(prefixCollisionTarget, prefixCollisionLink, 'junction');
+    symlinkSync(brokenTarget, brokenLink, 'junction');
+    rmSync(brokenTarget, { recursive: true, force: true });
+
+    await uninstallAllSkills([{ name: 'Shared Agents', skillsPath }]);
+
+    assert.equal(linkExists(ownedLink), false);
+    assert.equal(linkExists(unrelatedLink), true);
+    assert.equal(linkExists(prefixCollisionLink), true);
+    assert.equal(linkExists(brokenLink), true);
+    assert.equal(existsSync(unrelatedTarget), true);
+  `;
+
+  try {
+    const result = spawnSync(process.execPath, ['--input-type=module', '--eval', script], {
+      cwd: process.cwd(),
+      env: { ...process.env, HOME: home, USERPROFILE: home },
+      encoding: 'utf8',
+    });
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
Fixes #74

## What
Global uninstall now removes only symlinks that resolve inside Orchestra's canonical skills directory.

## Why
`uninstallAllSkills` previously removed every top-level symlink from detected agent skill directories. This could disconnect skills managed by other tools through shared directories such as `~/.agents/skills`.

## How
The uninstall path resolves each symlink and uses `path.relative()` to verify containment within the canonical directory before removing it. Links with targets outside that directory, dangling links, and similarly named paths such as `~/.orchestra/skills-other` are preserved.

## Testing
- Reproduced the original deletion behavior in an isolated temporary home directory.
- Added a Node test covering an Orchestra-owned link, an unrelated link, a canonical-prefix collision, and a dangling unrelated link.
- Ran `npm test` in `packages/ai-research-skills`.
- Ran `node --check src/installer.js` and `git diff --check`.